### PR TITLE
Rewrite `createSlice` to use a fluent interface

### DIFF
--- a/.changeset/three-socks-wait.md
+++ b/.changeset/three-socks-wait.md
@@ -1,0 +1,9 @@
+---
+"@sables/framework": minor
+"@sables/core": minor
+"@sables-app/example-side-effects": patch
+"@sables/router": patch
+"@sables-app/docs": patch
+---
+
+Rewrite `createSlice` to use a fluent interface

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ vite.config.js.timestamp-*
 
 # Build output
 dist
+
+# Created by `vitest typecheck`
+tsconfig.temp.json

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -12,9 +12,9 @@ Sables Core is made available from both the `@sables/core` and `@sables/framewor
 
 ### createSlice
 
-> `createSlice(options): EnhancedSlice;`
+> `createSlice(name, initialState): DraftSlice;`
 
-An enhanced version of [Redux Toolkit's `createSlice`](https://redux-toolkit.js.org/api/createslice), that returns enhanced slices.
+An enhanced version of Redux Toolkit's `createSlice` with a fluent interface.
 
 Enhanced slices contain selectors for slice state, and enhanced action creators.
 Enhanced action creators can create actions with dependencies, and have additional utility functions attached.
@@ -22,41 +22,35 @@ Enhanced action creators can create actions with dependencies, and have addition
 ##### Example
 
 ```ts
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: {},
-  reducers: {},
-});
-
-dogsSlice.selector(store.getState());
-```
-
-##### Complete example
-
-```ts
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: { puppyCount: 0 },
-  reducers: {
-    adoptPuppies(state, action: PayloadAction<string[]>) {
-      state.puppyCount += action.payload.length;
-    },
-  },
-});
-
-const { adoptPuppies } = dogsSlice.actions;
-const { selectDogsState } = dogsSlice;
-
-const selectPuppyCount = createSelector(
-  selectDogsState,
-  ({ puppyCount }) => puppyCount
+const booksSlice = createSlice("books", {
+  purchasedBookCount: 0,
+}).setReducer((builder) =>
+  builder.addCase(
+    "buyBooks",
+    (state, action: PayloadAction<string[]>) => {
+      state.purchasedBookCount += action.payload.length;
+    }
+  )
 );
 
-// `dogsSlice` is inserted into the store
-store.dispatch(adoptPuppies(["Fei", "Ekko"]));
+const { buyBooks } = booksSlice.actions;
+const { selectBooksState } = booksSlice;
 
-// Evaluates to `true`
-selectPuppyCount(store.getState()) === 2;
+// `booksSlice` is inserted into the store
+store.dispatch(
+  buyBooks([
+    "Goosebumps: Night of the Living Dummy",
+    "Goosebumps: Welcome to Dead House",
+  ])
+);
+
+const selectPurchasedBookCount = createSelector(
+  selectBooksState,
+  ({ purchasedBookCount }) => purchasedBookCount
+);
+
+// Returns `2`
+selectPurchasedBookCount(store.getState());
 ```
 
 ### enhanceSlice
@@ -82,6 +76,91 @@ dogsSlice.selector(store.getState());
 dogsSlice.selectDogsState(store.getState());
 ```
 
+### DraftSlice.setReducer
+
+> `DraftSlice.setReducer(buildReducerFn): EnhancedSlice;`
+
+`DraftSlice.setReducer` exposes a fluent interface for building a slice's reducer function.
+
+In comparison, Redux Toolkit's `createSlice` uses two different patterns when constructing a slice reducer.
+The `reducers` option accepts a reducer map object, while the `extraReducers` option accepts a build function.
+
+In contrast, `DraftSlice.setReducer` uses a single fluent interface for all reducer cases.
+
+##### Example
+
+```ts
+type PetName = string;
+
+const adoptCats = createAction<PetName[], "adoptCats">(
+  "adoptCats"
+);
+const adoptDogs = createAction<PetName[], "adoptDogs">(
+  "adoptDogs"
+);
+
+const slice = createSlice("pets", {
+  adoptedPetCount: 0,
+}).setReducer((builder) =>
+  builder
+    .addCase(
+      "adoptPuppies",
+      (state, action: PayloadAction<PetName[]>) => {
+        state.adoptedPetCount += action.payload.length;
+      }
+    )
+    .addCase(adoptDogs, (state, action) => {
+      state.adoptedPetCount += action.payload.length;
+    })
+    .addCases({
+      adoptKittens: (
+        state,
+        action: PayloadAction<PetName[]>
+      ) => {
+        state.adoptedPetCount += action.payload.length;
+      },
+    })
+    .addMatcher(adoptCats.match, (state, action) => {
+      state.adoptedPetCount += action.payload.length;
+    })
+    .addDefaultCase((state) => {
+      return state;
+    })
+);
+
+adoptDogs.dependsUpon(slice);
+adoptCats.dependsUpon(slice);
+
+const { adoptKittens, adoptPuppies } = petSlice.actions;
+```
+
+#### SliceReducerBuilder.addCase
+
+> `builder.addCase(actionType, caseReducer): SliceReducerBuilder;`
+>
+> `builder.addCase(actionCreator, caseReducer): SliceReducerBuilder;`
+
+Adds a reducer to handle a specific action.
+
+#### SliceReducerBuilder.addCases
+
+> `builder.addCases(reducersMap): SliceReducerBuilder;`
+
+Adds a map of reducers to handle specific actions.
+
+#### SliceReducerBuilder.addMatcher
+
+> `builder.addMatcher(actionMatcher, caseReducer): SliceReducerBuilder;`
+
+Adds a reducer to handle actions that meet the condition of the given match function.
+The given match function _must_ be a type guard for an action.
+
+#### SliceReducerBuilder.addDefaultCase
+
+> `builder.addDefaultCase(caseReducer): SliceReducerBuilder;`
+
+Adds a reducer to handle actions that aren't handled by other reducers.
+
 ### Slice.selector
 
 > `Slice.selector(storeState): SliceState;`
@@ -91,11 +170,9 @@ The selector is exposed on both the `selector` property, and a property based on
 For example, if the slice's name is `"books"`, the named selector will be called `selectBooksState`.
 
 ```ts
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: { puppyCount: 0 },
-  reducers: {},
-});
+const dogsSlice = createSlice("dogs", {
+  puppyCount: 0,
+}).setReducer((builder) => builder);
 
 const state = store.getState();
 
@@ -163,16 +240,15 @@ When a created action is dispatched, its dependencies are included.
 
 ```ts
 const adoptDog = createAction("adoptDog");
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: { adoptionCount: 0 },
-  reducers: {},
-  extraReducers(builder) {
-    builder.addCase(adoptDog, (state) => {
-      state.adoptionCount++;
-    });
-  },
-});
+
+const dogsSlice = createSlice("dogs", {
+  adoptionCount: 0,
+}).setReducer((builder) =>
+  builder.addCase(adoptDog, (state) => {
+    state.adoptionCount++;
+  })
+);
+
 const dogsObservable = createObservable(({ actions$ }) =>
   actions$.pipe(
     filter(adoptDog.match),
@@ -186,28 +262,26 @@ adoptDog.dependsUpon(dogsSlice, dogsObservable);
 ##### Add slice dependencies
 
 ```ts
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: { puppyCount: 0 },
-  reducers: {
-    adoptPuppies(state, action: PayloadAction<string[]>) {
+const dogsSlice = createSlice("dogs", {
+  puppyCount: 0,
+}).setReducer((builder) =>
+  builder.addCase(
+    "adoptPuppies",
+    (state, action: PayloadAction<string[]>) => {
       state.puppyCount += action.payload.length;
-    },
-  },
-});
+    }
+  )
+);
 
 const { adoptPuppies } = dogsSlice.actions;
 
-const catSlice = createSlice({
-  name: "cat",
-  initialState: { isAnnoyed: false },
-  reducers: {},
-  extraReducers(builder) {
-    builder.addCase(adoptPuppies, (state) => {
-      state.isAnnoyed = true;
-    });
-  },
-});
+const catSlice = createSlice("cat", {
+  isAnnoyed: false,
+}).setReducer((builder) =>
+  builder.addCase(adoptPuppies, (state) => {
+    state.isAnnoyed = true;
+  })
+);
 
 adoptPuppies.dependsUpon(catSlice);
 
@@ -391,14 +465,14 @@ interface Dog {
 
 const dogsEntityAdapter = createEntityAdapter<Dog>();
 
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: dogsEntityAdapter.getInitialState(),
-  reducers: entityAdapterToReducers(
-    dogsEntityAdapter,
-    "dog"
-  ),
-});
+const dogsSlice = createSlice(
+  "dogs",
+  dogsEntityAdapter.getInitialState()
+).setReducer((builder) =>
+  builder.addCases(
+    entityAdapterToReducers(dogsEntityAdapter, "dog")
+  )
+);
 
 // `addDog` is equal to `addOne` from Redux Toolkit
 const { addDog } = dogsSlice.actions;
@@ -417,15 +491,14 @@ const cactiAdapter = createEntityAdapter<Cactus>({
   sortComparer: (a, b) => a.name.localeCompare(b.name),
 });
 
-const cactiSlice = createSlice({
-  name: "cacti",
-  initialState: cactiAdapter.getInitialState(),
-  reducers: entityAdapterToReducers(
-    cactiAdapter,
-    "cactus",
-    "cacti"
-  ),
-});
+const cactiSlice = createSlice(
+  "cacti",
+  cactiAdapter.getInitialState()
+).setReducer((builder) =>
+  builder.addCases(
+    entityAdapterToReducers(cactiAdapter, "cactus", "cacti")
+  )
+);
 
 const { addCactus, addCacti } = cactiSlice.actions;
 
@@ -519,19 +592,14 @@ const notableBooks = createNotableEntities(
       payload.id,
   }
 );
-
-const booksSlice = createSlice({
-  name: "books",
-  initialState: {
-    ...booksAdapter.getInitialState(),
-    ...notableBooks.getInitialState(),
-  },
-  reducers: {
-    ...booksReducers,
-    ...notableBooks.reducers,
-  },
-});
-
+const booksSlice = createSlice("books", {
+  ...booksAdapter.getInitialState(),
+  ...notableBooks.getInitialState(),
+}).setReducer((builder) =>
+  builder
+    .addCases(booksReducers)
+    .addCases(notableBooks.reducers)
+);
 // Selectors are created for each adjective
 const { selectBestBook } = notableBooks.createSelectors(
   booksSlice.selectBooksState
@@ -573,11 +641,9 @@ When selectors with slice dependencies are used with [Sables' `useSelector`](#us
 ##### Example
 
 ```ts
-const booksSlice = createSlice({
-  name: "books",
-  initialState: { books: [] },
-  reducers: {},
-});
+const booksSlice = createSlice("books", {
+  books: [],
+}).setReducer((builder) => builder);
 
 const selectBooks = createSelector(
   booksSlice.selector,
@@ -599,11 +665,9 @@ An enhanced version of [`useSelector` from react-redux](https://react-redux.js.o
 ##### Example
 
 ```ts
-const booksSlice = createSlice({
-  name: "books",
-  initialState: { books: [] },
-  reducers: {},
-});
+const booksSlice = createSlice("books", {
+  books: [],
+}).setReducer((builder) => builder);
 
 const selectBooks = createSelector(
   booksSlice.selector,
@@ -611,7 +675,7 @@ const selectBooks = createSelector(
 );
 
 function MyComponent() {
-  // `booksSlice` is inserted
+  // `booksSlice` is asynchronously inserted
   const books = useSelector(selectBooks);
 
   return null;
@@ -1961,11 +2025,10 @@ Sets the initial reducer map for the Redux store reducer.
 ##### Example
 
 ```ts
-const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: {},
-  reducers: {},
-});
+const dogsSlice = ReduxToolkit.createSlice(
+  "dogs",
+  {}
+).setReducer((builder) => builder);
 
 function configureManager() {
   return createManager({
@@ -2001,13 +2064,17 @@ Asynchronously adds slices to the store.
 > automatically be inserted.
 
 ```ts
-const birdsSlice = createSlice({
-  name: "birds",
+const basicSlice = ReduxToolkit.createSlice({
+  name: "basic",
   initialState: {},
   reducers: {},
 });
+const enhancedSlice = ReduxToolkit.createSlice(
+  "enhanced",
+  {}
+).setReducer((builder) => builder);
 
-manager.store.insertSlices(birdsSlice);
+manager.store.insertSlices(birdsSlice, enhancedSlice);
 ```
 
 #### Manager.subscribeTo

--- a/examples/side-effects/src/dogsSlice.ts
+++ b/examples/side-effects/src/dogsSlice.ts
@@ -18,13 +18,13 @@ const dogsEntityAdapter = createEntityAdapter<Dog>({
   sortComparer: (dogA, dogB) => dogA.name.localeCompare(dogB.name),
 });
 
-export const dogsSlice = createSlice({
-  name: "dogs",
-  initialState: dogsEntityAdapter.getInitialState(),
-  reducers: entityAdapterToReducers(dogsEntityAdapter, "dog"),
-  extraReducers(builder) {
-    builder.addCase(dogSearch.actions.end, (state, action) => {
+export const dogsSlice = createSlice(
+  "dogs",
+  dogsEntityAdapter.getInitialState()
+).setReducer((builder) =>
+  builder
+    .addCases(entityAdapterToReducers(dogsEntityAdapter, "dog"))
+    .addCase(dogSearch.actions.end, (state, action) => {
       dogsEntityAdapter.addMany(state, action);
-    });
-  },
-});
+    })
+);

--- a/packages/core/src/Action.ts
+++ b/packages/core/src/Action.ts
@@ -159,25 +159,11 @@ export function enhanceAction<
  * dependencies, and have additional utility functions attached.
  *
  * @example
+ *
  * const wakeCat = createAction("wakeCat");
  *
- * const catSlice = createSlice({
- *   name: "cat",
- *   initialState: {
- *     sleep: true,
- *   },
- *   reducers: {},
- *   extraReducers: (builder) =>
- *     builder.addCase(wakeCat, (state) => {
- *       state.sleep = false;
- *     }),
- * })
- *
- * wakeCat.dependsUpon(catSlice);
- *
- * // The slice is automatically added to the store
- * // before the action is reduced into the store.
- * store.dispatch(wakeCat());
+ * // { type: "wakeCat", payload: undefined, error: false, meta: {} }
+ * const action = wakeCat();
  *
  * @public
  */

--- a/packages/core/src/Entity.ts
+++ b/packages/core/src/Entity.ts
@@ -50,15 +50,21 @@ namespace EntityReducers {
  *
  * @example
  *
- * interface Dog { id: number; name: string; }
+ * interface Dog {
+ *   id: number;
+ *   name: string;
+ * }
  *
  * const dogsEntityAdapter = createEntityAdapter<Dog>();
  *
- * export const dogsSlice = createSlice({
- *   name: "dogs",
- *   initialState: dogsEntityAdapter.getInitialState(),
- *   reducers: entityAdapterToReducers(dogsEntityAdapter, "dog"),
- * });
+ * const dogsSlice = createSlice(
+ *   "dogs",
+ *   dogsEntityAdapter.getInitialState()
+ * ).setReducer((builder) =>
+ *   builder.addCases(
+ *     entityAdapterToReducers(dogsEntityAdapter, "dog")
+ *   )
+ * );
  *
  * // `addDog` is equal to `addOne` from Redux Toolkit
  * const { addDog } = dogsSlice.actions;

--- a/packages/core/src/Selector.ts
+++ b/packages/core/src/Selector.ts
@@ -12,16 +12,15 @@ import {
 /**
  * An enhanced version of Reselect's `createSelector` function that
  * creates selectors with slice dependencies.
+ *
  * When selectors with slice dependencies are used with Sables' `useSelector`,
  * associated slices will automatically be inserted into the store.
  *
  * @example
  *
- * const booksSlice = createSlice({
- *   name: "books",
- *   initialState: { books: [] },
- *   reducers: {},
- * });
+ * const booksSlice = createSlice("books", {
+ *   books: [],
+ * }).setReducer((builder) => builder);
  *
  * const selectBooks = createSelector(
  *   booksSlice.selector,

--- a/packages/core/src/Slice.ts
+++ b/packages/core/src/Slice.ts
@@ -1,17 +1,22 @@
-import { capitalize, demandValue } from "@sables/utils";
+import { capitalize, demandValue, NoInfer } from "@sables/utils";
 
 import type * as ReduxToolkit from "@reduxjs/toolkit";
+import type * as Redux from "redux";
 
 import { createSliceReduxToolkit } from "../deps.js";
 import { enhanceAction } from "./Action.js";
 import { SYMBOL_LAZY_META, SYMBOL_LAZY_SELECTOR } from "./constants.js";
+import { hasLazyMeta } from "./main.js";
 import type {
+  ActionCreator,
   AnySlice,
   BaseSliceLazySelector,
   EnhancedActionCreator,
+  EnhancedActionCreatorWithPayload,
   EnhancedSlice,
   LazySliceSelectorName,
   LazySliceStoreState,
+  PayloadAction,
   SliceLazySelector,
   SliceName,
   StandardActionCreator,
@@ -124,8 +129,354 @@ export function enhanceSlice<S extends ReduxToolkit.Slice>(
   }) as EnhancedSlice<S>;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-namespace
+namespace SliceBuilder {
+  export type ActionTypeCase = [
+    actionType: string,
+    reducer: ReduxToolkit.CaseReducer<any, PayloadAction<any>>
+  ];
+
+  /**
+   * Unlike Redux Toolkit, Sables only accepts enhanced action creators.
+   */
+  export type ActionCreatorCase = [
+    actionCreator: ActionCreator<any, any[]>,
+    reducer: ReduxToolkit.CaseReducer<any, PayloadAction<any>>
+  ];
+
+  export type ActionMatcher<A extends Redux.AnyAction> = (
+    value: Redux.AnyAction
+  ) => value is A;
+
+  /**
+   * Unlike Redux Toolkit, Sables only accepts matcher that are type guards.
+   * Just returning a `boolean` isn't enough.
+   */
+  export type MatcherCase<A extends Redux.AnyAction = Redux.AnyAction> = [
+    actionMatcher: ActionMatcher<A>,
+    reducer: ReduxToolkit.CaseReducer<any, A>
+  ];
+
+  export type DefaultCase = [
+    empty: undefined,
+    reducer: ReduxToolkit.CaseReducer<any, Redux.AnyAction>
+  ];
+
+  export type Case =
+    | ActionTypeCase
+    | ActionCreatorCase
+    | MatcherCase
+    | DefaultCase;
+
+  export function isActionTypeCase(
+    reducerCase: SliceBuilder.Case
+  ): reducerCase is SliceBuilder.ActionTypeCase {
+    return typeof reducerCase[0] === "string";
+  }
+
+  export function isActionCreatorCase(
+    reducerCase: SliceBuilder.Case
+  ): reducerCase is SliceBuilder.ActionCreatorCase {
+    const [value] = reducerCase;
+
+    return typeof value === "function" && hasLazyMeta(value);
+  }
+
+  export function isMatcherCase(
+    reducerCase: SliceBuilder.Case
+  ): reducerCase is SliceBuilder.MatcherCase {
+    const [value] = reducerCase;
+
+    return typeof value === "function" && !hasLazyMeta(value);
+  }
+
+  export function isDefaultCase(
+    reducerCase: SliceBuilder.Case
+  ): reducerCase is SliceBuilder.DefaultCase {
+    return typeof reducerCase[0] === "undefined";
+  }
+}
+
+type CaseReducersFromSliceReducerBuilder<B> =
+  // First attempt to infer `CaseReducers` from `SliceReducerBuilderBase`
+  // prettier-ignore
+  B extends SliceReducerBuilderBase<any, infer C, any> ? C :
+  // Then attempt to infer `CaseReducers` from `SliceReducerBuilder`
+  // prettier-ignore
+  B extends SliceReducerBuilder<any, infer C, any> ? C : never;
+
+interface SliceReducerBuilderBase<
+  State,
+  CaseReducers extends ReduxToolkit.SliceCaseReducers<State>,
+  Name extends string
+> {
+  /** @internal */
+  _assemble(): EnhancedSlice<ReduxToolkit.Slice<State, CaseReducers, Name>>;
+}
+
+interface SliceReducerBuilder<
+  State,
+  CaseReducers extends ReduxToolkit.SliceCaseReducers<State>,
+  Name extends string
+> extends SliceReducerBuilderBase<State, CaseReducers, Name> {
+  /**
+   * Adds a reducer to handle a specific action.
+   *
+   * @public
+   */
+  addCase<
+    Type extends string,
+    R extends ReduxToolkit.CaseReducer<State, PayloadAction<any>>
+  >(
+    actionType: Type,
+    caseReducer: R
+  ): SliceReducerBuilder<State, CaseReducers & { [K in Type]: R }, Name>;
+  addCase<
+    AC extends EnhancedActionCreatorWithPayload<
+      ReduxToolkit.ActionCreatorWithPayload<any>
+    >
+  >(
+    actionCreator: AC,
+    caseReducer: ReduxToolkit.CaseReducer<State, ReturnType<AC>>
+  ): SliceReducerBuilder<State, CaseReducers, Name>;
+
+  /**
+   * Adds a map of reducers to handle specific actions.
+   *
+   * @public
+   */
+  addCases<C extends ReduxToolkit.SliceCaseReducers<State>>(
+    reducersMap: C
+  ): SliceReducerBuilder<State, CaseReducers & C, Name>;
+
+  /**
+   * Adds a reducer to handle actions that meet the condition of the given match function.
+   * The given match function _must_ be a type guard for an action.
+   *
+   * @public
+   */
+  addMatcher<A extends Redux.AnyAction>(
+    actionMatcher: SliceBuilder.ActionMatcher<A>,
+    caseReducer: ReduxToolkit.CaseReducer<State, A>
+  ): Omit<
+    SliceReducerBuilder<State, CaseReducers, Name>,
+    "addCase" | "addCases"
+  >;
+
+  /**
+   * Adds a reducer to handle actions that aren't handled by other reducers.
+   *
+   * @public
+   */
+  addDefaultCase(
+    caseReducer: ReduxToolkit.CaseReducer<State, Redux.AnyAction>
+  ): SliceReducerBuilderBase<State, CaseReducers, Name>;
+}
+
+function createSliceReducerBuilder<
+  State,
+  CaseReducers extends ReduxToolkit.SliceCaseReducers<State>,
+  Name extends string
+>(
+  name: Name,
+  initialState: State,
+  cases: SliceBuilder.Case[]
+): SliceReducerBuilder<State, CaseReducers, Name> {
+  function getReducersOption() {
+    return cases.reduce<ReduxToolkit.SliceCaseReducers<State>>(
+      (result, reducerCase) => {
+        if (SliceBuilder.isActionTypeCase(reducerCase)) {
+          const [actionTypeOrCreator, reducer] = reducerCase;
+
+          return {
+            ...result,
+            [actionTypeOrCreator]: reducer,
+          };
+        }
+
+        return result;
+      },
+      {}
+    );
+  }
+
+  function getExtraReducersOption() {
+    return (builder: ReduxToolkit.ActionReducerMapBuilder<NoInfer<State>>) => {
+      for (const reducerCase of cases) {
+        if (SliceBuilder.isActionCreatorCase(reducerCase)) {
+          builder.addCase(...reducerCase);
+        }
+        if (SliceBuilder.isMatcherCase(reducerCase)) {
+          builder.addMatcher(...reducerCase);
+        }
+        if (SliceBuilder.isDefaultCase(reducerCase)) {
+          const [, reducer] = reducerCase;
+          builder.addDefaultCase(reducer);
+        }
+      }
+    };
+  }
+
+  function createBaseSlice() {
+    return createSliceReduxToolkit({
+      name,
+      initialState,
+      reducers: getReducersOption(),
+      extraReducers: getExtraReducersOption(),
+    });
+  }
+
+  function addCase(...reducerCase: SliceBuilder.Case) {
+    return createSliceReducerBuilder(name, initialState, [
+      ...cases,
+      reducerCase,
+    ]);
+  }
+
+  function addCases<C extends ReduxToolkit.SliceCaseReducers<State>>(
+    reducers: C
+  ) {
+    const nextCases = Object.entries(reducers) as SliceBuilder.Case[];
+
+    return createSliceReducerBuilder(name, initialState, [
+      ...cases,
+      ...nextCases,
+    ]);
+  }
+
+  function addDefaultCase(
+    reducer: ReduxToolkit.CaseReducer<State, Redux.AnyAction>
+  ) {
+    return createSliceReducerBuilder(name, initialState, [
+      ...cases,
+      [undefined, reducer],
+    ]);
+  }
+
+  function addMatcher(...reducerCase: SliceBuilder.MatcherCase) {
+    return createSliceReducerBuilder(name, initialState, [
+      ...cases,
+      reducerCase,
+    ]);
+  }
+
+  function _assemble() {
+    return enhanceSlice(createBaseSlice());
+  }
+
+  const builder = {
+    _assemble,
+    addCase,
+    addCases,
+    addDefaultCase,
+    addMatcher,
+    // Casting to avoid unnecessary generic propagation
+  } as unknown as SliceReducerBuilder<State, CaseReducers, Name>;
+
+  return builder;
+}
+
+/** @public */
+type DraftSlice<State, Name extends string = string> = {
+  /**
+   *
+   * @example
+   *
+   * type PetName = string;
+   *
+   * const adoptCats = createAction<PetName[], "adoptCats">(
+   *   "adoptCats"
+   * );
+   * const adoptDogs = createAction<PetName[], "adoptDogs">(
+   *   "adoptDogs"
+   * );
+   *
+   * const slice = createSlice("pets", {
+   *   adoptedPetCount: 0,
+   * }).setReducer((builder) =>
+   *   builder
+   *     .addCase(
+   *       "adoptPuppies",
+   *       (state, action: PayloadAction<PetName[]>) => {
+   *         state.adoptedPetCount += action.payload.length;
+   *       }
+   *     )
+   *     .addCase(adoptDogs, (state, action) => {
+   *       state.adoptedPetCount += action.payload.length;
+   *     })
+   *     .addCases({
+   *       adoptKittens: (
+   *         state,
+   *         action: PayloadAction<PetName[]>
+   *       ) => {
+   *         state.adoptedPetCount += action.payload.length;
+   *       },
+   *     })
+   *     .addMatcher(adoptCats.match, (state, action) => {
+   *       state.adoptedPetCount += action.payload.length;
+   *     })
+   *     .addDefaultCase((state) => {
+   *       return state;
+   *     })
+   * );
+   *
+   * adoptDogs.dependsUpon(slice);
+   * adoptCats.dependsUpon(slice);
+   *
+   * const { adoptKittens, adoptPuppies } = petSlice.actions;
+   *
+   * @public
+   */
+  setReducer<
+    B extends SliceReducerBuilderBase<
+      State,
+      ReduxToolkit.SliceCaseReducers<State>,
+      Name
+    >
+  >(
+    buildReducerFn: (
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      builder: SliceReducerBuilder<State, {}, Name>
+    ) => B
+  ): EnhancedSlice<
+    ReduxToolkit.Slice<State, CaseReducersFromSliceReducerBuilder<B>, Name>
+  >;
+};
+
 /**
- * An enhanced version of Redux Toolkit's `createSlice`.
+ * An enhanced version of Redux Toolkit's `createSlice` with a fluent interface.
+ *
+ * @example
+ *
+ * const booksSlice = createSlice("books", {
+ *   purchasedBookCount: 0,
+ * }).setReducer((builder) =>
+ *   builder.addCase(
+ *     "buyBooks",
+ *     (state, action: PayloadAction<string[]>) => {
+ *       state.purchasedBookCount += action.payload.length;
+ *     }
+ *   )
+ * );
+ *
+ * const { buyBooks } = booksSlice.actions;
+ * const { selectBooksState } = booksSlice;
+ *
+ * // `booksSlice` is inserted into the store
+ * store.dispatch(
+ *   buyBooks([
+ *     "Goosebumps: Night of the Living Dummy",
+ *     "Goosebumps: Welcome to Dead House",
+ *   ])
+ * );
+ *
+ * const selectPurchasedBookCount = createSelector(
+ *   selectBooksState,
+ *   ({ purchasedBookCount }) => purchasedBookCount
+ * );
+ *
+ * // Returns `2`
+ * selectPurchasedBookCount(store.getState());
  *
  * @see {@link https://sables.dev/api#createslice `createSlice` documentation}
  * @see {@link https://redux-toolkit.js.org/api/createslice `ReduxToolkit.createSlice` documentation}
@@ -133,10 +484,21 @@ export function enhanceSlice<S extends ReduxToolkit.Slice>(
  *
  * @public
  */
-export function createSlice<
-  State,
-  CaseReducers extends ReduxToolkit.SliceCaseReducers<State>,
-  Name extends string = string
->(options: ReduxToolkit.CreateSliceOptions<State, CaseReducers, Name>) {
-  return enhanceSlice(createSliceReduxToolkit(options));
+export function createSlice<State, Name extends string = string>(
+  name: Name,
+  initialState: State
+): DraftSlice<State, Name> {
+  return {
+    setReducer(buildReducerFn) {
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      const initialBuilder = createSliceReducerBuilder<State, {}, Name>(
+        name,
+        initialState,
+        []
+      );
+      const finalBuilder = buildReducerFn(initialBuilder);
+
+      return finalBuilder._assemble() as any;
+    },
+  };
 }

--- a/packages/core/src/__tests__/Action.spec.ts
+++ b/packages/core/src/__tests__/Action.spec.ts
@@ -22,19 +22,13 @@ describe("Action", () => {
       const statesPromise = firstValueFrom(
         storeStates$.pipe(take(3), toArray())
       );
-
       const wakeCat = createAction("wakeCat");
-      const catsSlice = createSlice({
-        name: "cat",
-        initialState: {
-          sleep: true,
-        },
-        reducers: {},
-        extraReducers: (builder) =>
+      const catsSlice = createSlice("cat", { sleep: true }).setReducer(
+        (builder) =>
           builder.addCase(wakeCat, (state, action) => {
             state.sleep = false;
-          }),
-      });
+          })
+      );
 
       wakeCat.dependsUpon(catsSlice);
 
@@ -112,16 +106,12 @@ describe("Action", () => {
         const { store } = createTestStore(vitest);
 
         const adoptDog = createAction("adoptDog");
-        const dogsSlice = createSlice({
-          name: "dogs",
-          initialState: { adoptionCount: 0 },
-          reducers: {},
-          extraReducers(builder) {
+        const dogsSlice = createSlice("dogs", { adoptionCount: 0 }).setReducer(
+          (builder) =>
             builder.addCase(adoptDog, (state) => {
               state.adoptionCount++;
-            });
-          },
-        });
+            })
+        );
         const tapStub = vitest.vi.fn();
         const dogsObservable = createObservable(({ actions$ }) =>
           actions$.pipe(filter(adoptDog.match), tap(tapStub))

--- a/packages/core/src/__tests__/Entity.spec.ts
+++ b/packages/core/src/__tests__/Entity.spec.ts
@@ -29,12 +29,10 @@ describe("Entity", () => {
 
     function createTestConstructs() {
       const bookReducers = entityAdapterToReducers(booksAdapter, "book");
-
-      const booksSlice = createSlice({
-        name: "books",
-        initialState: booksAdapter.getInitialState(),
-        reducers: bookReducers,
-      });
+      const booksSlice = createSlice(
+        "books",
+        booksAdapter.getInitialState()
+      ).setReducer((builder) => builder.addCases(bookReducers));
 
       return { bookReducers, booksSlice };
     }
@@ -149,17 +147,12 @@ describe("Entity", () => {
         favorite: (id: string) => id,
       });
 
-      const booksSlice = createSlice({
-        name: "books",
-        initialState: {
-          ...booksAdapter.getInitialState(),
-          ...notableBooks.getInitialState(),
-        },
-        reducers: {
-          ...bookReducers,
-          ...notableBooks.reducers,
-        },
-      });
+      const booksSlice = createSlice("books", {
+        ...booksAdapter.getInitialState(),
+        ...notableBooks.getInitialState(),
+      }).setReducer((builder) =>
+        builder.addCases(bookReducers).addCases(notableBooks.reducers)
+      );
 
       const { selectBestBook, selectWorstBook, selectFavoriteBook } =
         notableBooks.createSelectors(booksSlice.selectBooksState);

--- a/packages/core/src/__tests__/Selector.spec.tsx
+++ b/packages/core/src/__tests__/Selector.spec.tsx
@@ -9,12 +9,9 @@ import { hasLazyMeta } from "../utils.js";
 
 describe("Selector", () => {
   function createTestSlice() {
-    return createSlice({
-      name: "cat",
-      reducers: {},
-      initialState: { sleep: true },
-    });
+    return createSlice("cat", { sleep: true }).setReducer((builder) => builder);
   }
+
   function createTestSelector() {
     return createSelector(testSlice.selectCatState, ({ sleep }) => sleep);
   }

--- a/packages/core/src/__tests__/Slice.spec.ts
+++ b/packages/core/src/__tests__/Slice.spec.ts
@@ -1,23 +1,24 @@
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import { firstValueFrom, take, toArray } from "rxjs";
 import * as vitest from "vitest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { assertType, beforeEach, describe, expect, it, test } from "vitest";
 
 import { SYMBOL_LAZY_META } from "../constants.js";
+import { createAction } from "../main.js";
 import { createSlice } from "../Slice.js";
-import { PayloadAction } from "../types.js";
+import { EnhancedActionCreatorWithPayload, PayloadAction } from "../types.js";
 import { createTestStore } from "./utils.js";
 
 describe("createSlice", () => {
   function createDogsSlice() {
-    return createSlice({
-      name: "dogs",
-      initialState: { puppyCount: 0 },
-      reducers: {
-        adoptPuppies(state, action: PayloadAction<string[]>) {
+    return createSlice("dogs", { puppyCount: 0 }).setReducer((builder) =>
+      builder.addCase(
+        "adoptPuppies",
+        (state, action: PayloadAction<string[]>) => {
           state.puppyCount += action.payload.length;
-        },
-      },
-    });
+        }
+      )
+    );
   }
 
   let dogsSlice: ReturnType<typeof createDogsSlice>;
@@ -72,16 +73,12 @@ describe("createSlice", () => {
     it("enhanced actions can set dependencies", async () => {
       const { store } = createTestStore(vitest);
       const { adoptPuppies } = dogsSlice.actions;
-      const catSlice = createSlice({
-        name: "cat",
-        initialState: { isAnnoyed: false },
-        reducers: {},
-        extraReducers(builder) {
+      const catSlice = createSlice("cat", { isAnnoyed: false }).setReducer(
+        (builder) =>
           builder.addCase(adoptPuppies, (state) => {
             state.isAnnoyed = true;
-          });
-        },
-      });
+          })
+      );
 
       adoptPuppies.dependsUpon(catSlice);
 
@@ -110,5 +107,99 @@ describe("createSlice", () => {
         );
       }
     });
+  });
+
+  describe("created slices", () => {
+    it("reduces slices from different sources", async () => {
+      type PetName = string;
+      const adoptCats = createAction<PetName[]>("adoptCats");
+      const adoptDogs = createAction<PetName[]>("adoptDogs");
+
+      const petSlice = createSlice("pets", {
+        adoptedPetCount: 0,
+      }).setReducer((builder) =>
+        builder
+          .addCase(
+            "adoptPuppies",
+            (state, action: PayloadAction<PetName[]>) => {
+              state.adoptedPetCount += action.payload.length;
+            }
+          )
+          .addCase(adoptDogs, (state, action) => {
+            state.adoptedPetCount += action.payload.length;
+          })
+          .addCases({
+            adoptKittens: (state, action: PayloadAction<PetName[]>) => {
+              state.adoptedPetCount += action.payload.length;
+            },
+          })
+          .addMatcher(adoptCats.match, (state, action) => {
+            state.adoptedPetCount += action.payload.length;
+          })
+          .addDefaultCase((state) => {
+            return state;
+          })
+      );
+
+      adoptDogs.dependsUpon(petSlice);
+      adoptCats.dependsUpon(petSlice);
+
+      const { adoptKittens, adoptPuppies } = petSlice.actions;
+      const { store } = createTestStore(vitest);
+
+      store.dispatch(adoptDogs(["Pay", "Tai"]));
+      store.dispatch(adoptCats(["Rex", "Ace"]));
+      store.dispatch(adoptKittens(["Amy", "May"]));
+      store.dispatch(adoptPuppies(["Max", "Dex"]));
+
+      expect(store.getState()).toEqual({
+        pets: {
+          adoptedPetCount: 8,
+        },
+      });
+    });
+  });
+
+  test("createSlice types", () => {
+    const sliceDraft = createSlice("books", { purchasedBookCount: 0 });
+    const slice = sliceDraft.setReducer((initialBuilder) => {
+      const finalBuilder = initialBuilder.addCase(
+        "buyBooks",
+        (state, action: PayloadAction<string[]>) => {
+          state.purchasedBookCount += action.payload.length;
+        }
+      );
+      return finalBuilder;
+    });
+
+    const action = slice.actions.buyBooks([
+      "Goosebumps: Night of the Living Dummy",
+      "Goosebumps: Welcome to Dead House",
+    ]);
+
+    assertType<string[]>(action.payload);
+    assertType<"books/buyBooks">(action.type);
+    assertType<string>(action.type);
+    // @ts-expect-error The `buyBooks` action type should be
+    // strictly "books/buyBooks"
+    assertType<"foo">(action.type);
+    // It can match the more generic `PayloadAction` type
+    assertType<PayloadAction<string[]>>(action);
+
+    assertType<
+      EnhancedActionCreatorWithPayload<
+        ActionCreatorWithPayload<string[], "books/buyBooks">
+      >
+    >(slice.actions.buyBooks);
+
+    // @ts-expect-error `buyBooks` should requires a payload
+    slice.actions.buyBooks();
+
+    slice.actions.buyBooks([
+      // @ts-expect-error `buyBooks` should only accept a string array
+      true,
+      "Goosebumps: Night of the Living Dummy",
+      "Goosebumps: Welcome to Dead House",
+    ]);
   });
 });

--- a/packages/core/src/hooks/Selector.ts
+++ b/packages/core/src/hooks/Selector.ts
@@ -20,11 +20,9 @@ import { getSlicesFromSelector } from "../utils.js";
  *
  * @example
  *
- * const booksSlice = createSlice({
- *   name: "books",
- *   initialState: { books: [] },
- *   reducers: {},
- * });
+ * const booksSlice = createSlice("books", {
+ *   books: [],
+ * }).setReducer((builder) => builder);
  *
  * const selectBooks = createSelector(
  *   booksSlice.selector,
@@ -32,7 +30,7 @@ import { getSlicesFromSelector } from "../utils.js";
  * );
  *
  * function MyComponent() {
- *   // `booksSlice` is inserted
+ *   // `booksSlice` is asynchronously inserted
  *   const books = useSelector(selectBooks);
  *
  *   return null;

--- a/packages/core/src/hooks/__tests__/Selector.spec.tsx
+++ b/packages/core/src/hooks/__tests__/Selector.spec.tsx
@@ -10,12 +10,9 @@ import { useSelector } from "../Selector.js";
 
 describe("Selector", () => {
   function createTestSlice() {
-    return createSlice({
-      name: "cat",
-      reducers: {},
-      initialState: { sleep: true },
-    });
+    return createSlice("cat", { sleep: true }).setReducer((builder) => builder);
   }
+
   function createTestSelector() {
     return createSelector(testSlice.selectCatState, ({ sleep }) => sleep);
   }

--- a/packages/core/src/middleware/ActionDependencyEnhancer.ts
+++ b/packages/core/src/middleware/ActionDependencyEnhancer.ts
@@ -58,13 +58,17 @@ export type LazySlicesEnhancerExt<
    *
    * @example
    *
-   * const birdsSlice = createSlice({
-   *   name: "birds",
+   * const basicSlice = ReduxToolkit.createSlice({
+   *   name: "basic",
    *   initialState: {},
    *   reducers: {},
    * });
+   * const enhancedSlice = ReduxToolkit.createSlice(
+   *   "enhanced",
+   *   {}
+   * ).setReducer((builder) => builder);
    *
-   * manager.store.insertSlices(birdsSlice);
+   * manager.store.insertSlices(birdsSlice, enhancedSlice);
    *
    * @privateRemarks
    *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -256,6 +256,18 @@ export type EnhancedSlice<S extends ReduxToolkit.Slice = ReduxToolkit.Slice> =
        * The selector is exposed on both the `selector` property, and a property based on the slice's `name`.
        * For example, if the slice's name is `"books"`, the named selector will be called `selectBooksState`.
        *
+       * @example
+       *
+       * const dogsSlice = createSlice("dogs", {
+       *   puppyCount: 0,
+       * }).setReducer((builder) => builder);
+       *
+       * const state = store.getState();
+       *
+       * // Both return `0`
+       * dogsSlice.selectDogsState(state).puppyCount;
+       * dogsSlice.selector(state).puppyCount;
+       *
        * @see {@link https://sables.dev/api#sliceselector Slice.selector}
        *
        * @public

--- a/packages/framework/src/manager/Manager.ts
+++ b/packages/framework/src/manager/Manager.ts
@@ -116,11 +116,10 @@ export interface CreateManagerOptions<
    *
    * @example
    *
-   * const dogsSlice = createSlice({
-   *   name: "dogs",
-   *   initialState: {},
-   *   reducers: {}
-   * });
+   * const dogsSlice = ReduxToolkit.createSlice(
+   *   "dogs",
+   *   {}
+   * ).setReducer((builder) => builder);
    *
    * function configureManager() {
    *   return createManager({

--- a/packages/router/src/configureRouter.ts
+++ b/packages/router/src/configureRouter.ts
@@ -24,7 +24,7 @@ import { attachRoutesCollectionToStore } from "./StoreEnhancer.js";
 import { CombinedRouterState, InitialLocation } from "./types.js";
 
 function createRouterSlice(routerReducer: Redux.Reducer<RouterState>) {
-  /* eslint-disable @typescript-eslint/ban-types */
+  // eslint-disable-next-line @typescript-eslint/ban-types
   const slice: ReduxToolkit.Slice<RouterState, {}, typeof ROUTER_REDUCER_KEY> =
     {
       name: ROUTER_REDUCER_KEY,

--- a/packages/router/src/routeTransitionSlice.ts
+++ b/packages/router/src/routeTransitionSlice.ts
@@ -30,31 +30,31 @@ export const transitionRoute = createSideEffectActions<
 >("sables/transitionRoute");
 
 /** @internal */
-export const routeTransitionSlice = createSlice({
-  name: "sablesRouteTransition",
-  initialState: createInitialState(),
-  reducers: {
-    reportTransitionResult(state, action: PayloadAction<SSRTransitionResult>) {
-      state._ssrTransitionResult = action.payload;
-    },
-  },
-  extraReducers(builder) {
-    builder
-      .addCase(transitionRoute.start, (state) => {
-        state.isTransitioning = true;
-      })
-      .addCase(transitionRoute.end, (state, action) => {
-        state.isTransitioning = false;
+export const routeTransitionSlice = createSlice(
+  "sablesRouteTransition",
+  createInitialState()
+).setReducer((builder) =>
+  builder
+    .addCase(
+      "reportTransitionResult",
+      (state, action: PayloadAction<SSRTransitionResult>) => {
+        state._ssrTransitionResult = action.payload;
+      }
+    )
+    .addCase(transitionRoute.start, (state) => {
+      state.isTransitioning = true;
+    })
+    .addCase(transitionRoute.end, (state, action) => {
+      state.isTransitioning = false;
 
-        const { nextRoute } = action.payload;
+      const { nextRoute } = action.payload;
 
-        if (nextRoute !== undefined && nextRoute !== state.currentRoute) {
-          state.prevRoute = state.currentRoute;
-          state.currentRoute = nextRoute;
-        }
-      });
-  },
-});
+      if (nextRoute !== undefined && nextRoute !== state.currentRoute) {
+        state.prevRoute = state.currentRoute;
+        state.currentRoute = nextRoute;
+      }
+    })
+);
 
 transitionRoute.dependsUpon(routeTransitionSlice);
 


### PR DESCRIPTION
### Overview

1. Rewrite `createSlice` to use a fluent interface
2. Drop support for Redux Toolkit's interface
    - Redux Toolkit's interface can still be used with `enhanceSlice`
