### PR TITLE
feat: Add `definePath` and `defineParam`

### DIFF
--- a/.changeset/hungry-lobsters-sin.md
+++ b/.changeset/hungry-lobsters-sin.md
@@ -1,0 +1,6 @@
+---
+"@sables/router": minor
+"@sables/framework": minor
+---
+
+Add support for strict route parameter types using [`definePath`](https://sables.dev/docs/api#definepath).

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1712,6 +1712,60 @@ createRoutes().setEffects(() =>
 );
 ```
 
+### definePath
+
+> `definePath\`/route/path/${":parameterName"}\``
+
+A [tagged template][] that enables strict typing of route parameters. Using `definePath` for routes with many parameters is recommended but optional.
+
+[tagged template]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
+
+Sables Router considers route parameter values to be user input, so they aren't trusted.
+As a result, the types defined by `definePath` should only be used to check interface compatibility.
+For example, `definePath` types can be used to check whether an associated validation schema has correct property names.
+
+##### Example
+
+```ts
+const routes = createRoutes()
+  .set("root", "/")
+  .set("profile", definePath`/profiles/${":handle"}`);
+
+// No type error
+routes.Profile.build({ handle: "@ash.ketchum" });
+// @ts-expect-error The `build` method doesn't accept invalid params
+routes.Profile.build({ foo: "bar" });
+```
+
+##### See also
+
+- [`defineParam`](#defineparam)
+
+### defineParam
+
+> `defineParam(":parameterName")`
+
+A helper function to assist in defining paths using [`definePath`](#definepath).
+`defineParam` coerces TypeScript to infer a string literal type instead of `string`.
+Writing `defineParam(":parameterName")` is effectively the same as writing
+`":parameterName" as const`.
+
+##### Example
+
+```ts
+const profilePath = definePath`/profiles/${defineParam(
+  ":handle"
+)}`;
+
+const routes = createRoutes()
+  .set("root", "/")
+  .set("profile", profilePath);
+```
+
+##### See also
+
+- [`definePath`](#definepath)
+
 ### Route middleware signals
 
 A route middleware signal is an object thrown within a

--- a/packages/router/src/Path.ts
+++ b/packages/router/src/Path.ts
@@ -1,0 +1,197 @@
+import { Path as ParserPath } from "path-parser";
+
+import { AnyRoutePath, RoutePathType, WildCardPathType } from "./types";
+
+/** @internal */
+export const RAW_WILDCARD_PARAM_NAME = "*";
+
+/** @internal */
+export const PARSER_WILDCARD_PARAM_NAME = "wildcard";
+
+/**
+ * @public
+ */
+export type TemplatePath<Path extends AnyRoutePath, RawParamName> = Readonly<{
+  /** @internal */
+  _pieces?: ReadonlyArray<string>;
+  /** @internal */
+  _rawParamNames?: RawParamName[];
+  path: Path;
+}>;
+
+/** @internal */
+export type PathFromRawParamName<RawParamName> = Extract<
+  RawParamName,
+  typeof RAW_WILDCARD_PARAM_NAME
+> extends never
+  ? RoutePathType
+  : WildCardPathType;
+
+/** @internal */
+export type PathFromParamName<ParamName> = Extract<
+  ParamName,
+  typeof PARSER_WILDCARD_PARAM_NAME
+> extends never
+  ? RoutePathType
+  : WildCardPathType;
+
+/** @internal */
+export type TemplatePathFromRawParamName<RawParamName> = TemplatePath<
+  PathFromRawParamName<RawParamName>,
+  RawParamName
+>;
+
+type RawParamNameType = `:${string}` | typeof RAW_WILDCARD_PARAM_NAME;
+
+/** @internal */
+export type ExtractParamName<RawParamName> =
+  RawParamName extends `:${infer ParamName}`
+    ? ParamName
+    : typeof PARSER_WILDCARD_PARAM_NAME;
+
+/**
+ * A helper function to assist in defining paths using [`definePath`](#definepath).
+ * `defineParam` coerces TypeScript to infer a string literal type instead of `string`.
+ * Writing `defineParam(":parameterName")` is effectively the same as writing
+ * `":parameterName" as const`.
+ *
+ * @example
+ *
+ * const profilePath = definePath`/profiles/${defineParam(
+ *   ":handle"
+ * )}`;
+ *
+ * const routes = createRoutes()
+ *   .set("root", "/")
+ *   .set("profile", profilePath);
+ *
+ * @see {definePath}
+ *
+ * @public
+ */
+export function defineParam<RawParamName extends RawParamNameType>(
+  rawParamName: RawParamName
+): RawParamName {
+  return rawParamName;
+}
+
+/**
+ * A tagged template that enables strict typing of route parameters.
+ * Using `definePath` for routes with many parameters is recommended but optional.
+ *
+ * Sables Router considers route parameter values to be user input,so they aren't trusted.
+ * As a result, the types defined by `definePath` should only be used to check interface
+ * compatibility. For example, `definePath` types can be used to check whether an associated
+ * validation schema has correct property names.
+ *
+ * @see {@link https://sables.dev/docs/api#definepath definePath documentation}
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates MDN: Tagged Template documentation}
+ *
+ * @example
+ *
+ * const routes = createRoutes()
+ *   .set("root", "/")
+ *   .set("profile", definePath`/profiles/${":handle"}`);
+ *
+ * // No type error
+ * routes.Profile.build({ handle: "@ash.ketchum" });
+ * // @ts-expect-error The `build` method doesn't accept invalid params
+ * routes.Profile.build({ foo: "bar" });
+ *
+ * @public
+ */
+export function definePath<RawParamName>(
+  pieces: TemplateStringsArray,
+  ...rawParamNames: RawParamName[]
+): TemplatePathFromRawParamName<RawParamName> {
+  const path = pieces.reduce(
+    (result, piece, index) => `${result}${piece}${rawParamNames[index] || ""}`,
+    ""
+  );
+
+  assertRoutePathType(path);
+
+  return {
+    _pieces: pieces,
+    _rawParamNames: rawParamNames,
+    path: path as PathFromRawParamName<RawParamName>,
+  };
+}
+
+/** @internal */
+export function routePathToTemplatePath<Path extends RoutePathType>(
+  path: Path
+): TemplatePath<Path, unknown> {
+  return { path };
+}
+
+/** @internal */
+export function isWildCardPath(path: AnyRoutePath): path is WildCardPathType {
+  return path.endsWith("/*");
+}
+
+/** @internal */
+export function assertWildCardRoutePath(
+  path: AnyRoutePath
+): asserts path is WildCardPathType {
+  if (!isWildCardPath(path)) {
+    throw new Error(`The provided route path must be a wildcard path.`);
+  }
+}
+
+/** @internal */
+export function assertNotWildCardRoutePath(
+  path: AnyRoutePath
+): asserts path is RoutePathType {
+  if (isWildCardPath(path)) {
+    throw new Error(`The provided route path must not be a wildcard path.`);
+  }
+}
+
+/** @internal */
+export function assertWildCardRouteTemplatePath<ParamName = any>(
+  templatePath: TemplatePath<any, ParamName>
+): asserts templatePath is TemplatePath<WildCardPathType, ParamName> {
+  console.log(templatePath.path);
+  if (!isWildCardPath(templatePath.path)) {
+    throw new Error(`The provided route path must be a wildcard path.`);
+  }
+}
+
+/** @internal */
+export function assertNotWildCardRouteTemplatePath<ParamName = any>(
+  templatePath: TemplatePath<any, ParamName>
+): asserts templatePath is TemplatePath<RoutePathType, ParamName> {
+  if (isWildCardPath(templatePath.path)) {
+    throw new Error(`The provided route path must not be a wildcard path.`);
+  }
+}
+
+/** @internal */
+export function assertRoutePathType(
+  path: string
+): asserts path is RoutePathType {
+  if (!path.startsWith("/")) {
+    throw new Error("Route paths much begin with a forward slash (/).");
+  }
+}
+
+/** @internal */
+export function normalizeRoutePath<Path extends RoutePathType>(
+  pathInput: Path | TemplatePath<Path, any>
+): TemplatePath<Path, any> {
+  return typeof pathInput == "string"
+    ? routePathToTemplatePath(pathInput)
+    : pathInput;
+}
+
+/** @internal */
+export function createPathParser(
+  templatePath: TemplatePath<AnyRoutePath, unknown>
+) {
+  const parserPath = isWildCardPath(templatePath.path)
+    ? `${templatePath.path}${PARSER_WILDCARD_PARAM_NAME}`
+    : templatePath.path;
+
+  return new ParserPath(parserPath);
+}

--- a/packages/router/src/RoutesCollection.ts
+++ b/packages/router/src/RoutesCollection.ts
@@ -3,7 +3,12 @@ import {
   SYMBOL_ROUTES_COLLECTION_INSTANCE,
 } from "@sables/core";
 
-import { createRoutes, RouteReference, Routes } from "./Routes.js";
+import {
+  createRoutes,
+  RouteReference,
+  RouteReferenceInfo,
+  Routes,
+} from "./Routes.js";
 import type { MatchingHref, RouteID, RouteWithParams } from "./types.js";
 
 /** @internal */
@@ -29,7 +34,7 @@ export function createRoutesCollection<
 >(): RoutesCollection<EffectAPI> {
   let collection = new Set<Routes<EffectAPI>>();
   let defaultInitialRoutes:
-    | Routes<EffectAPI, typeof DEFAULT_ROOT_ID>
+    | Routes<EffectAPI, RouteReferenceInfo<typeof DEFAULT_ROOT_ID, string>>
     | undefined;
 
   const routesCollection: RoutesCollection<EffectAPI> = {

--- a/packages/router/src/__tests__/Path.spec.ts
+++ b/packages/router/src/__tests__/Path.spec.ts
@@ -1,0 +1,124 @@
+import { assertType, describe, expect, it, test } from "vitest";
+
+import { defineParam, definePath } from "../Path.js";
+import { createRoutes } from "../Routes.js";
+import { MatchingHref } from "../types.js";
+
+describe("Routes", () => {
+  describe("definePath", () => {
+    // TODO - Break this apart into smaller tests
+    test("types", () => {
+      expect(() => {
+        createRoutes()
+          // @ts-expect-error The defined route isn't a wildcard
+          .setWildcard("invalidWildcard", definePath`/profiles/${":handle"}`);
+      }).toThrowError();
+
+      const routes = createRoutes()
+        .set("root", "/")
+        .set("profile", definePath`/profiles/${":handle"}`)
+        .set("definedRoute", definePath`/boom/${":pow"}/${":kaboom"}`)
+        .setWildcard("validWildcard", definePath`/foo/${":bar"}/${"*"}`);
+
+      const paramPath = definePath`/profiles/${defineParam(":handle")}`;
+      const multiPath = definePath`/boom/${defineParam(":pow")}/${defineParam(
+        ":kaboom"
+      )}`;
+      const wildcardPath = definePath`/foo/${defineParam(":bar")}/${defineParam(
+        "*"
+      )}`;
+
+      // `defineParam` infers params
+      assertType<
+        Readonly<{
+          _pieces?: readonly string[] | undefined;
+          _rawParamNames?: ":handle"[] | undefined;
+          path: `/${string}`;
+        }>
+      >(paramPath);
+
+      // `defineParam` infers multiple params
+      assertType<
+        Readonly<{
+          _pieces?: readonly string[] | undefined;
+          _rawParamNames?: (":pow" | ":kaboom")[] | undefined;
+          path: `/${string}`;
+        }>
+      >(multiPath);
+
+      // `defineParam` infers wildcard params
+      assertType<
+        Readonly<{
+          _pieces?: readonly string[] | undefined;
+          _rawParamNames?: (":bar" | "*")[] | undefined;
+          path: `/${string}/*`;
+        }>
+      >(wildcardPath);
+
+      expect(paramPath).toMatchSnapshot();
+      expect(multiPath).toMatchSnapshot();
+      expect(wildcardPath).toMatchSnapshot();
+
+      // The `build` accepts valid params
+      routes.Profile.build({ handle: "@ash.ketchum" });
+      expect(() => {
+        // @ts-expect-error The `build` method doesn't accept invalid params
+        routes.Profile.build({ foo: "bar" });
+      }).toThrowError();
+
+      expect(routes.Profile).toMatchSnapshot();
+      expect(routes.ValidWildcard).toMatchSnapshot();
+      expect(routes.DefinedRoute).toMatchSnapshot();
+
+      // Strictly infers path types
+      assertType<
+        Readonly<{
+          build(
+            params?: Record<"handle", unknown> | null | undefined
+          ): `/${string}`;
+          id: "profile";
+          path: `/${string}`;
+          test(href: MatchingHref): Record<"handle", unknown> | null;
+          match(href: MatchingHref): boolean;
+          toString(): "profile";
+        }>
+      >(routes.Profile);
+
+      // Strictly infers wildcard path types
+      assertType<
+        Readonly<{
+          build(
+            params?: Record<"wildcard" | "bar", unknown> | null | undefined
+          ): `/${string}`;
+          id: "validWildcard";
+          path: `/${string}/*`;
+          test(href: MatchingHref): Record<"wildcard", unknown> | null;
+          match(href: MatchingHref): boolean;
+          toString(): "validWildcard";
+        }>
+      >(routes.ValidWildcard);
+
+      // Infers types for multiple parameters
+      assertType<
+        Readonly<{
+          build(
+            params?: Record<"pow" | "kaboom", unknown> | null | undefined
+          ): `/${string}`;
+          id: "definedRoute";
+          path: `/${string}`;
+          test(href: MatchingHref): Record<"pow" | "kaboom", unknown> | null;
+          match(href: MatchingHref): boolean;
+          toString(): "definedRoute";
+        }>
+      >(routes.DefinedRoute);
+
+      const profileRoute = routes.find("/profiles/@ash.ketchum");
+
+      expect(profileRoute).toEqual({
+        id: "profile",
+        path: "/profiles/:handle",
+        params: { handle: "@ash.ketchum" },
+      });
+    });
+  });
+});

--- a/packages/router/src/__tests__/__snapshots__/Path.spec.ts.snap
+++ b/packages/router/src/__tests__/__snapshots__/Path.spec.ts.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1
+
+exports[`Routes > definePath > types 1`] = `
+{
+  "_pieces": [
+    "/profiles/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":handle",
+  ],
+  "path": "/profiles/:handle",
+}
+`;
+
+exports[`Routes > definePath > types 2`] = `
+{
+  "_pieces": [
+    "/boom/",
+    "/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":pow",
+    ":kaboom",
+  ],
+  "path": "/boom/:pow/:kaboom",
+}
+`;
+
+exports[`Routes > definePath > types 3`] = `
+{
+  "_pieces": [
+    "/foo/",
+    "/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":bar",
+    "*",
+  ],
+  "path": "/foo/:bar/*",
+}
+`;
+
+exports[`Routes > definePath > types 4`] = `
+{
+  "build": [Function],
+  "id": "profile",
+  "match": [Function],
+  "path": "/profiles/:handle",
+  "test": [Function],
+  "toString": [Function],
+}
+`;
+
+exports[`Routes > definePath > types 5`] = `
+{
+  "build": [Function],
+  "id": "validWildcard",
+  "match": [Function],
+  "path": "/foo/:bar/*",
+  "test": [Function],
+  "toString": [Function],
+}
+`;
+
+exports[`Routes > definePath > types 6`] = `
+{
+  "build": [Function],
+  "id": "definedRoute",
+  "match": [Function],
+  "path": "/boom/:pow/:kaboom",
+  "test": [Function],
+  "toString": [Function],
+}
+`;

--- a/packages/router/src/__tests__/__snapshots__/Routes.spec.ts.snap
+++ b/packages/router/src/__tests__/__snapshots__/Routes.spec.ts.snap
@@ -1,0 +1,77 @@
+// Vitest Snapshot v1
+
+exports[`Routes > definePath > types 1`] = `
+{
+  "_pieces": [
+    "/profiles/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":handle",
+  ],
+  "path": "/profiles/:handle",
+}
+`;
+
+exports[`Routes > definePath > types 2`] = `
+{
+  "_pieces": [
+    "/boom/",
+    "/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":pow",
+    ":kaboom",
+  ],
+  "path": "/boom/:pow/:kaboom",
+}
+`;
+
+exports[`Routes > definePath > types 3`] = `
+{
+  "_pieces": [
+    "/foo/",
+    "/",
+    "",
+  ],
+  "_rawParamNames": [
+    ":bar",
+    "*",
+  ],
+  "path": "/foo/:bar/*",
+}
+`;
+
+exports[`Routes > definePath > types 4`] = `
+{
+  "build": [Function],
+  "id": "profile",
+  "match": [Function],
+  "path": "/profiles/:handle",
+  "test": [Function],
+  "toString": [Function],
+}
+`;
+
+exports[`Routes > definePath > types 5`] = `
+{
+  "build": [Function],
+  "id": "validWildcard",
+  "match": [Function],
+  "path": "/foo/:bar/*",
+  "test": [Function],
+  "toString": [Function],
+}
+`;
+
+exports[`Routes > definePath > types 6`] = `
+{
+  "build": [Function],
+  "id": "definedRoute",
+  "match": [Function],
+  "path": "/boom/:pow/:kaboom",
+  "test": [Function],
+  "toString": [Function],
+}
+`;

--- a/packages/router/src/main.ts
+++ b/packages/router/src/main.ts
@@ -12,6 +12,7 @@ export * from "./constants.js";
 export * from "./Router.js";
 export * from "./effects.js";
 export * from "./hooks.js";
+export { defineParam, definePath } from "./Path.js";
 export * from "./RouteEffects.js";
 export * from "./Routes.js";
 export * from "./RoutesCollection.js";

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -7,7 +7,6 @@ import type { SlicesToReducersMapObject } from "@sables/utils";
 
 import type * as ReduxToolkit from "@reduxjs/toolkit";
 import type * as History from "history";
-import type * as PathParser from "path-parser";
 import type * as Redux from "redux";
 import type * as ReduxFirstHistory from "redux-first-history";
 
@@ -17,7 +16,7 @@ import type {
   ROUTER_REDUCER_KEY,
   transitionStatuses,
 } from "./constants.js";
-import type { AnyRouteReference, RouteReference } from "./Routes.js";
+import type { AnyRouteReference } from "./Routes.js";
 import type { routeTransitionSlice } from "./routeTransitionSlice.js";
 
 /**


### PR DESCRIPTION
### Overview

Add support for strict route parameter types using `definePath`.