### PR TITLE
Propagate stricter route param types

### DIFF
--- a/.changeset/rich-bobcats-camp.md
+++ b/.changeset/rich-bobcats-camp.md
@@ -1,0 +1,6 @@
+---
+"@sables/framework": minor
+"@sables/router": minor
+---
+
+Propagate stricter route param types. Various APIs enforce stricter types for route params.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1714,7 +1714,11 @@ createRoutes().setEffects(() =>
 
 ### definePath
 
-> <p><code>definePath&#96;/route/path/$\{":parameterName"}&#96;</code></p>
+> <p>
+>   <code>
+>     definePath&#96;/route/path/$\{":parameterName"}&#96;
+>   </code>
+> </p>
 
 A [tagged template][] that enables strict typing of route parameters. Using `definePath` for routes with many parameters is recommended but optional.
 

--- a/packages/core/src/Action.ts
+++ b/packages/core/src/Action.ts
@@ -35,7 +35,9 @@ export function isEnhancedActionCreator<
   A extends StandardAction<T> = StandardAction<T>
 >(
   actionCreator: BasicActionCreator<T, P, A>
-): actionCreator is EnhancedStandardActionCreator<StandardActionCreator<T, P, A>> {
+): actionCreator is EnhancedStandardActionCreator<
+  StandardActionCreator<T, P, A>
+> {
   return hasLazyMeta(actionCreator);
 }
 

--- a/packages/framework/src/manager/ManagerInstance.ts
+++ b/packages/framework/src/manager/ManagerInstance.ts
@@ -5,7 +5,12 @@ import {
   SYMBOL_EFFECT_API_ROUTES,
   SYMBOL_MANAGER_EFFECT_API,
 } from "@sables/core";
-import { BuildHrefOptions, buildLink, RoutesCollection } from "@sables/router";
+import {
+  BuildHrefInput,
+  BuildHrefOptions,
+  buildLink,
+  RoutesCollection,
+} from "@sables/router";
 import type { MutableReferenceObject } from "@sables/utils";
 
 import type * as History from "history";
@@ -39,8 +44,8 @@ export function createManagerInstance<
     [SYMBOL_EFFECT_API_ROUTES]: routesCollectionRef,
     [SYMBOL_MANAGER_EFFECT_API]: effectAPIRef,
     actions$,
-    buildLink(...args: BuildHrefOptions) {
-      return buildLink(dispatch, args);
+    buildLink<Route extends BuildHrefInput>(...args: BuildHrefOptions<Route>) {
+      return buildLink<Route>(dispatch, args);
     },
     dispatch,
     getState,

--- a/packages/framework/src/types.ts
+++ b/packages/framework/src/types.ts
@@ -7,6 +7,7 @@ import type {
   SYMBOL_MANAGER_EFFECT_API,
 } from "@sables/core";
 import type {
+  BuildHrefInput,
   BuildHrefOptions,
   CombinedRouterState,
   InitialLocation,
@@ -39,7 +40,9 @@ export type ManagerStore<
 
 /** @internal */
 export interface ManagerMethodsOnly {
-  buildLink: (...buildHrefArgs: BuildHrefOptions) => RouteLink;
+  buildLink<Route extends BuildHrefInput>(
+    ...buildHrefArgs: BuildHrefOptions<Route>
+  ): RouteLink;
   history: History.History;
 }
 

--- a/packages/router/src/RouteTransitionMiddleware.ts
+++ b/packages/router/src/RouteTransitionMiddleware.ts
@@ -36,6 +36,7 @@ import {
   selectIsRouteTransitioning,
 } from "./selectors.js";
 import type {
+  BuildHrefInput,
   EndRouteTransitionReason,
   EndTransitionAction,
   LocationChangeAction,
@@ -68,8 +69,8 @@ export function createRouteTransitionMiddleware<
   const routesCollection = createRoutesCollection<EffectAPI>();
   const actions$ = new ActionSubject();
 
-  function destinationToLocation(
-    dest: NavigationDestination
+  function destinationToLocation<Route extends BuildHrefInput>(
+    dest: NavigationDestination<Route>
   ): RouteHref | PartialHistoryPathStrict {
     if (typeof dest == "string") {
       return dest;
@@ -84,7 +85,9 @@ export function createRouteTransitionMiddleware<
     return buildHref(dest);
   }
 
-  function destinationToHref(dest: NavigationDestination): RouteHref {
+  function destinationToHref<Route extends BuildHrefInput>(
+    dest: NavigationDestination<Route>
+  ): RouteHref {
     const location = destinationToLocation(dest);
 
     return typeof location == "string" ? location : buildHref(location);

--- a/packages/router/src/actions.ts
+++ b/packages/router/src/actions.ts
@@ -1,4 +1,10 @@
-import { createAction, enhanceAction } from "@sables/core";
+import {
+  createAction,
+  DecoratedBasicActionCreator,
+  enhanceAction,
+  EnhancedStandardActionCreator,
+  PayloadAction,
+} from "@sables/core";
 
 import type { History } from "history";
 import { Action as HistoryAction } from "history";
@@ -15,7 +21,11 @@ import {
 import type { CallHistoryMethodAction } from "redux-first-history/build/es6/actions";
 
 import { routeTransitionSlice } from "./routeTransitionSlice.js";
-import { LocationChangeAction, NavigationDestination } from "./types.js";
+import {
+  BuildHrefInput,
+  LocationChangeAction,
+  NavigationDestination,
+} from "./types.js";
 
 /**
  * Utilities for the location change action.
@@ -132,6 +142,17 @@ export const pushLocation = enhanceAction(push, CALL_HISTORY_METHOD);
  */
 export const replaceLocation = enhanceAction(replace, CALL_HISTORY_METHOD);
 
+type EnsureLocationType = "sablesRouter/ensureLocation";
+
+type EnsureLocation = EnhancedStandardActionCreator<
+  DecoratedBasicActionCreator<
+    EnsureLocationType,
+    <Route extends BuildHrefInput>(
+      payload: NavigationDestination<Route>
+    ) => PayloadAction<NavigationDestination<Route>, EnsureLocationType>
+  >
+>;
+
 /**
  * An action creator. When its actions are dispatched, middleware will
  * checks if the current location matches the given destination.
@@ -142,9 +163,10 @@ export const replaceLocation = enhanceAction(replace, CALL_HISTORY_METHOD);
  *
  * @public
  */
-export const ensureLocation = createAction<NavigationDestination>(
-  "sablesRouter/ensureLocation"
-);
+export const ensureLocation = createAction<
+  NavigationDestination<BuildHrefInput>,
+  EnsureLocationType
+>("sablesRouter/ensureLocation") as EnsureLocation;
 
 /**
  * Used to add router slices during router initialization.

--- a/packages/router/src/effects.ts
+++ b/packages/router/src/effects.ts
@@ -4,6 +4,7 @@ import { isSSREnv } from "@sables/utils";
 
 import type { Routes } from "./Routes.js";
 import type {
+  BuildHrefInput,
   DynamicImportFn,
   NavigationDestination,
   RouteEffectHandlers,
@@ -126,9 +127,11 @@ export class AddRoutesSignal<
  *
  * @public
  */
-export class ForwardRouteSignal extends RouteMiddlewareSignal {
+export class ForwardRouteSignal<
+  Route extends BuildHrefInput
+> extends RouteMiddlewareSignal {
   constructor(
-    public destination: NavigationDestination,
+    public destination: NavigationDestination<Route>,
     message = "Forwarding route."
   ) {
     super(message);
@@ -242,9 +245,10 @@ export function logTransition<
  * @public
  */
 export function forwardTo<
-  EffectAPI extends DefaultEffectAPI = DefaultEffectAPI
+  EffectAPI extends DefaultEffectAPI = DefaultEffectAPI,
+  Route extends BuildHrefInput = BuildHrefInput
 >(
-  getDestination: (params: RouteParams) => NavigationDestination
+  getDestination: (params: RouteParams) => NavigationDestination<Route>
 ): RouteMiddleware<StartTransitionAction, EffectAPI> {
   return async (action, effectAPI, abortSignal) => {
     if (abortSignal.aborted) return;

--- a/packages/router/src/hooks.ts
+++ b/packages/router/src/hooks.ts
@@ -3,7 +3,14 @@ import { useEffectAPI } from "@sables/core";
 import { MouseEventHandler, useCallback, useMemo, useRef } from "react";
 import { useDispatch } from "react-redux";
 
-import type { BuildHrefOptions, DynamicImportFn, RouteLink } from "./types.js";
+import { AnyRouteReference } from "./Routes.js";
+import type {
+  BuildHrefInput,
+  BuildHrefOptions,
+  DynamicImportFn,
+  PartialHistoryPathStrict,
+  RouteLink,
+} from "./types.js";
 import { buildLink, createDynamicImportRegistrar } from "./utils.js";
 
 /**
@@ -31,14 +38,12 @@ import { buildLink, createDynamicImportRegistrar } from "./utils.js";
  *
  * @public
  */
-export function useLink(...options: BuildHrefOptions): RouteLink {
-  const [route, params] = options;
+export function useLink<Route extends BuildHrefInput>(
+  ...options: BuildHrefOptions<Route>
+): RouteLink {
   const dispatch = useDispatch();
 
-  return useMemo(
-    () => buildLink(dispatch, [route, params]),
-    [route, params, dispatch]
-  );
+  return useMemo(() => buildLink(dispatch, options), [options, dispatch]);
 }
 
 /**
@@ -63,9 +68,11 @@ export function useLink(...options: BuildHrefOptions): RouteLink {
  *
  * @public
  */
-export function useLinkProps(
+export function useLinkProps<
+  Route extends AnyRouteReference | PartialHistoryPathStrict
+>(
   onClick?: MouseEventHandler<HTMLAnchorElement>,
-  ...options: BuildHrefOptions
+  ...options: BuildHrefOptions<Route>
 ) {
   const { href, ensureLocation } = useLink(...options);
   const handleClick = useCallback<MouseEventHandler<HTMLAnchorElement>>(

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -16,7 +16,7 @@ import type {
   ROUTER_REDUCER_KEY,
   transitionStatuses,
 } from "./constants.js";
-import type { AnyRouteReference } from "./Routes.js";
+import type { AnyRouteReference, RouteReferenceParams } from "./Routes.js";
 import type { routeTransitionSlice } from "./routeTransitionSlice.js";
 
 /**
@@ -300,6 +300,9 @@ export type PartialHistoryPathStrict = {
  */
 export type PartialHistoryPath = Partial<History.Path>;
 
+/** @internal */
+export type BuildHrefInput = AnyRouteReference | PartialHistoryPathStrict;
+
 /**
  * Parameters used to build a hyperlink for a route.
  *
@@ -313,10 +316,12 @@ export type PartialHistoryPath = Partial<History.Path>;
  *
  * @public
  */
-export type BuildHrefOptions = [
-  route?: AnyRouteReference | PartialHistoryPathStrict,
-  params?: RouteParams
-];
+export type BuildHrefOptions<Route extends BuildHrefInput> =
+  Route extends AnyRouteReference
+    ? RouteReferenceParams<Route> extends Record<string, unknown>
+      ? [route: Route, params: RouteReferenceParams<Route>]
+      : [route: Route, params?: Record<string, unknown>]
+    : [route?: Route];
 
 /**
  * A representation of a location to be navigated to.
@@ -326,9 +331,9 @@ export type BuildHrefOptions = [
  *
  * @public
  */
-export type NavigationDestination =
+export type NavigationDestination<Route extends BuildHrefInput> =
   | AnyRouteReference
-  | BuildHrefOptions
+  | BuildHrefOptions<Route>
   | PartialHistoryPathStrict
   | RouteHref;
 
@@ -339,9 +344,9 @@ export type NavigationDestination =
  *
  * @public
  */
-export type BuildLinkParams = [
+export type BuildLinkParams<Route extends BuildHrefInput> = [
   dispatch: Redux.Dispatch,
-  buildHrefOptions: BuildHrefOptions
+  buildHrefOptions: BuildHrefOptions<Route>
 ];
 
 /** @internal */

--- a/packages/router/src/utils.ts
+++ b/packages/router/src/utils.ts
@@ -11,6 +11,7 @@ import { ensureLocation, pushLocation, replaceLocation } from "./actions.js";
 import { AnyRouteReference } from "./Routes.js";
 import { isRoutesCollection, RoutesCollection } from "./RoutesCollection.js";
 import type {
+  BuildHrefInput,
   BuildHrefOptions,
   BuildLinkParams,
   LocationChangeAction,
@@ -40,8 +41,8 @@ export function areLocationChangesRouterEquivalent(
 }
 
 /** @internal */
-export function isPartialHistoryPath(
-  value?: AnyRouteReference | PartialHistoryPathStrict | BuildHrefOptions
+export function isPartialHistoryPath<Route extends BuildHrefInput>(
+  value?: AnyRouteReference | PartialHistoryPathStrict | BuildHrefOptions<Route>
 ): value is PartialHistoryPathStrict {
   return (
     typeof value === "object" &&
@@ -61,7 +62,9 @@ const FALLBACK_HREF = "/";
  *
  * @public
  */
-export function buildHref(...args: BuildHrefOptions): RouteHref {
+export function buildHref<Route extends BuildHrefInput>(
+  ...args: BuildHrefOptions<Route>
+): RouteHref {
   const [route, params] = args;
 
   if (isPartialHistoryPath(route)) {
@@ -80,7 +83,9 @@ export function buildHref(...args: BuildHrefOptions): RouteHref {
  *
  * @public
  */
-export function buildLink(...args: BuildLinkParams): RouteLink {
+export function buildLink<Route extends BuildHrefInput>(
+  ...args: BuildLinkParams<Route>
+): RouteLink {
   const [dispatch, buildHrefArgs] = args;
   const href = buildHref(...buildHrefArgs);
 

--- a/website/scripts/publishAssets.cjs
+++ b/website/scripts/publishAssets.cjs
@@ -10,8 +10,12 @@ const mime = require("mime-types");
 const fs = require("fs-jetpack");
 
 function getContext() {
-  const { CLOUDFLARE_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET } =
-    process.env;
+  const {
+    CLOUDFLARE_ACCOUNT_ID,
+    R2_ACCESS_KEY_ID,
+    R2_SECRET_ACCESS_KEY,
+    R2_BUCKET,
+  } = process.env;
 
   return {
     accountId: CLOUDFLARE_ACCOUNT_ID,


### PR DESCRIPTION
### Overview

The following APIs enforce stricter types for route params:

- `buildHref`
- `buildLink`
- `ensureLocation`
- `forwardTo`
- `manager.buildLink`
- `useLink`
- `useLinkProps`