### PR TITLE
Update action creator hooks

### DIFF
--- a/.changeset/some-random-words.md
+++ b/.changeset/some-random-words.md
@@ -1,0 +1,6 @@
+---
+"@sables/core": minor
+"@sables-app/docs": minor
+---
+
+Add `useActionCallback` hook.

--- a/.changeset/strange-ravens-beg.md
+++ b/.changeset/strange-ravens-beg.md
@@ -1,0 +1,6 @@
+---
+"@sables/core": minor
+"@sables-app/docs": minor
+---
+
+Rename `useWithDispatch` to `useAction`.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Sables is an application-first Web framework focused on distributed routing logi
 - [Getting Started guide](https://sables.dev/docs/getting-started)
 - [API Reference](https://sables.dev/docs/api)
 
+### Versioning
+
+Sables adheres to [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
 ### License
 
 Copyright &copy; 2022 [Morris Allison III](http://morris.xyz).

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -721,10 +721,9 @@ A higher-order component that assigns props to the given component.
 ```ts
 const Link = withProps("a", { className: "link" });
 const ButtonLink = withProps(Link, { role: "button" });
-const A11yButtonLink = withProps(
-  ButtonLink,
-  (props) => ({ "aria-label": props.title })
-);
+const A11yButtonLink = withProps(ButtonLink, (props) => ({
+  "aria-label": props.title,
+}));
 ```
 
 ### createSelector
@@ -805,9 +804,9 @@ function MyComponent() {
 }
 ```
 
-### useWithDispatch
+### useAction
 
-> `useWithDispatch(...actionCreators): BoundActionCreator[];`
+> `useAction(...actionCreators): BoundActionCreator[];`
 
 A React hook that binds the given action creators to the dispatch
 function available in the context.
@@ -818,13 +817,37 @@ function available in the context.
 const sayHello = createAction("sayHello");
 
 function MyComponent() {
-  const [dispatchSayHello] = useWithDispatch(sayHello);
+  const [dispatchSayHello] = useAction(sayHello);
 
   return (
     <button
       type="button"
       onClick={() => dispatchSayHello()}
     >
+      Hello!
+    </button>
+  );
+}
+```
+
+### useActionCallback
+
+> `useActionCallback(actionCreator, payload): () => void;`
+
+A React hook that binds the given payload action creator to the dispatch
+function available in the context. When called, an action is
+dispatched with the given payload.
+
+##### Example
+
+```tsx
+const sayHello = createAction<string>("sayHello");
+
+function MyComponent() {
+  const sayHelloMary = useActionCallback(sayHello, "Mary");
+
+  return (
+    <button type="button" onClick={sayHelloMary}>
       Hello!
     </button>
   );

--- a/packages/core/src/hooks/__tests__/Action.spec.ts
+++ b/packages/core/src/hooks/__tests__/Action.spec.ts
@@ -1,28 +1,60 @@
 import * as vitest from "vitest";
-import { beforeEach, describe, expect, it } from "vitest";
+import { assertType, beforeEach, describe, expect, it } from "vitest";
 
 import { createAction, enhanceAction } from "../../Action.js";
-import { useWithDispatch } from "../Action.js";
+import { useAction, useActionCallback } from "../Action.js";
 
+// TODO - Add render time assertions
 describe("framework/hooks/Action", () => {
-  describe("useWithDispatch", () => {
-    it("returns memoized array of action creators bound to dispatch", async () => {
-      const firstAction = createAction<{ foo: boolean }>("firstAction");
-      const secondAction = createAction("secondAction");
-      const thirdAction = enhanceAction(function thirdAction(
-        time: Date,
-        text: string
-      ) {
-        return {
-          type: "thirdAction",
-          payload: { time, text },
-        } as const;
-      });
+  const firstActionCreator = createAction<{ foo: boolean }>("firstAction");
+  const secondActionCreator = createAction("secondAction");
+  const thirdActionCreator = enhanceAction(function thirdAction(
+    time: Date,
+    text: string
+  ) {
+    return {
+      type: "thirdAction",
+      payload: { time, text },
+    } as const;
+  });
 
+  describe("useAction", () => {
+    it("returns memoized array of action creators bound to dispatch", async () => {
       function Foo() {
         const [dispatchFirstAction, dispatchSecondAction, dispatchThirdAction] =
-          useWithDispatch(firstAction, secondAction, thirdAction);
+          useAction(
+            firstActionCreator,
+            secondActionCreator,
+            thirdActionCreator
+          );
+
+        assertType<(payload: { foo: boolean }) => void>(dispatchFirstAction);
+        assertType<(payload?: void | undefined) => void>(dispatchSecondAction);
+        assertType<(time: Date, text: string) => void>(dispatchThirdAction);
+
+        assertType<void>(dispatchFirstAction({ foo: true }));
+        assertType<void>(dispatchSecondAction());
+        assertType<void>(dispatchThirdAction(new Date(), "hello"));
       }
+    });
+
+    describe("useActionCallback", () => {
+      it("returns memoized array of action creators bound to dispatch", async () => {
+        function Foo() {
+          const firstAction = useActionCallback(firstActionCreator, {
+            foo: true,
+          });
+          // No error, action creators with `void` payloads can be called
+          // without providing the second parameter
+          const secondAction = useActionCallback(secondActionCreator);
+          // @ts-expect-error The hook only accepts payload action creators
+          const thirdAction = useActionCallback(thirdActionCreator, 1 as any);
+
+          assertType<() => void>(firstAction);
+          assertType<() => void>(secondAction);
+          assertType<() => void>(thirdAction);
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
### Overview

- Rename `useWithDispatch` to `useAction`.
- Add `useActionCallback` hook.