### PR TITLE
Re-export common types from Redux

### DIFF
--- a/.changeset/cold-jeans-itch.md
+++ b/.changeset/cold-jeans-itch.md
@@ -1,0 +1,5 @@
+---
+"@sables/core": minor
+---
+
+Re-export `AnyAction`, `Dispatch`, and `Middleware` types from Redux for convenience.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -775,12 +775,13 @@ const selectBooks = createSelector(
 
 An enhanced version of [`useSelector` from react-redux](https://react-redux.js.org/api/hooks#useselector) that asynchronously inserts slices from selector dependencies.
 
-> _This method is optional._
->
-> When slices are properly set as dependencies of actions,
-> the usage of this hook isn't necessary. However, using this
-> hook will help cover developer mistakes when a slice isn't
-> set as dependency by accident.
+<div className="highlight-info">
+
+> It's unnecessary to use this hook for JIT slice insertion to function.
+> However, using it over the `react-redux` variant may help cover developer
+> mistakes where a slice isn't set as an action dependency.
+
+</div>
 
 ##### Example
 

--- a/packages/core/deps.d.ts
+++ b/packages/core/deps.d.ts
@@ -7,4 +7,6 @@ export {
   Dictionary,
 } from "@reduxjs/toolkit";
 
+export { AnyAction, Dispatch, Middleware } from "redux";
+
 export { Selector } from "reselect";

--- a/packages/core/src/hooks/Selector.ts
+++ b/packages/core/src/hooks/Selector.ts
@@ -11,12 +11,9 @@ import { getSlicesFromSelector } from "../utils.js";
  *
  * @remarks
  *
- * **This method is optional.**
- *
- * When slices are properly set as dependencies of actions,
- * the usage of this hook isn't necessary. However, using this
- * hook will help cover developer mistakes when a slice isn't
- * set as dependency by accident.
+ * It's unnecessary to use this hook for JIT slice insertion to function.
+ * However, using it over the `react-redux` variant may help cover developer
+ * mistakes where a slice isn't set as an action dependency.
  *
  * @example
  *


### PR DESCRIPTION
### Overview

Re-export `AnyAction`, `Dispatch`, and `Middleware` types from Redux for convenience.