### PR TITLE
Update route effects methods

### DIFF
--- a/.changeset/nasty-lobsters-jump.md
+++ b/.changeset/nasty-lobsters-jump.md
@@ -1,0 +1,5 @@
+---
+"@sables/router": minor
+---
+
+Allow `RouteReference` objects to be used with route effects methods.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1224,7 +1224,7 @@ createRouteEffects()
   .prepend("legacyRoot", forwardTo("/"))
   // Lazy-load routes when a location matches the Profiles wildcard route
   .append(
-    initialRoutes.Profiles.id,
+    initialRoutes.Profiles,
     addRoutes(() => import("./profileRoutes.js"))
   );
 ```
@@ -1257,7 +1257,7 @@ _`RouteEffects` methods include:_
 
 #### RouteEffects.append
 
-> `RouteEffects.append(routeID, routeMiddleware): RouteEffects;`
+> `RouteEffects.append(routeInput, routeMiddleware): RouteEffects;`
 
 Adds middleware for the given route to the end of the stack.
 
@@ -1267,7 +1267,7 @@ Adds middleware for the given route to the end of the stack.
 const routes = createRoutes().set("root", "/");
 
 createRouteEffects().append(
-  routes.Root.id,
+  routes.Root,
   delayTransition(5000)
 );
 ```
@@ -1288,7 +1288,7 @@ createRouteEffects().appendAll(delayTransition(5000));
 
 #### RouteEffects.prepend
 
-> `RouteEffects.prepend(routeID, routeMiddleware): RouteEffects;`
+> `RouteEffects.prepend(routeInput, routeMiddleware): RouteEffects;`
 
 Adds middleware for the given route to the beginning of the stack.
 
@@ -1319,7 +1319,7 @@ createRouteEffects().prependAll(delayTransition(5000));
 
 #### RouteEffects.onComplete
 
-> `RouteEffects.onComplete(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onComplete(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route completes.
 
@@ -1351,7 +1351,7 @@ createRouteEffects().onCompleteAll(() => {
 
 #### RouteEffects.onEnd
 
-> `RouteEffects.onEnd(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onEnd(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route ends.
 
@@ -1383,7 +1383,7 @@ createRouteEffects().onEndAll(() => {
 
 #### RouteEffects.onExit
 
-> `RouteEffects.onExit(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onExit(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route exits.
 
@@ -1415,7 +1415,7 @@ createRouteEffects().onExitAll(() => {
 
 #### RouteEffects.onFailure
 
-> `RouteEffects.onFailure(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onFailure(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route fails.
 
@@ -1447,7 +1447,7 @@ createRouteEffects().onFailureAll(() => {
 
 #### RouteEffects.onInterrupt
 
-> `RouteEffects.onInterrupt(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onInterrupt(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route interrupts.
 
@@ -1479,7 +1479,7 @@ createRouteEffects().onInterruptAll(() => {
 
 #### RouteEffects.onStart
 
-> `RouteEffects.onStart(routeID, routeListener): RouteEffects;`
+> `RouteEffects.onStart(routeInput, routeListener): RouteEffects;`
 
 Adds a route listener that's called when a route transition for the given route starts.
 

--- a/packages/router/src/Routes.ts
+++ b/packages/router/src/Routes.ts
@@ -27,7 +27,6 @@ import {
   TemplatePath,
 } from "./Path.js";
 import {
-  cloneRouteEffects,
   createRouteEffects,
   RouteEffects,
   UntouchedRouteEffects,
@@ -66,7 +65,7 @@ function cloneRoutesMeta<EffectAPI extends DefaultEffectAPI>(
 ): RoutesMeta<EffectAPI> {
   return {
     externalEffectsFn: routesMeta.externalEffectsFn,
-    internalEffects: cloneRouteEffects(routesMeta.internalEffects),
+    internalEffects: routesMeta.internalEffects._clone(),
     routesById: new Map(routesMeta.routesById.entries()),
   };
 }

--- a/packages/router/src/__tests__/RouteEffects.spec.ts
+++ b/packages/router/src/__tests__/RouteEffects.spec.ts
@@ -6,7 +6,7 @@ import { createRoutes } from "../Routes.js";
 
 describe("RoutesEffects", () => {
   describe("createRoutesEffects", () => {
-    test.only("appending route middleware", () => {
+    test("appending route middleware", () => {
       const routes = createRoutes()
         .set("root", "/")
         .set("profile", "/profiles/:handle")

--- a/packages/router/src/__tests__/RouteEffects.spec.ts
+++ b/packages/router/src/__tests__/RouteEffects.spec.ts
@@ -1,0 +1,34 @@
+import { assertType, describe, expect, it, test } from "vitest";
+
+import { delayTransition } from "../effects.js";
+import { createRouteEffects } from "../RouteEffects.js";
+import { createRoutes } from "../Routes.js";
+
+describe("RoutesEffects", () => {
+  describe("createRoutesEffects", () => {
+    test.only("appending route middleware", () => {
+      const routes = createRoutes()
+        .set("root", "/")
+        .set("profile", "/profiles/:handle")
+        .set("what", "/what");
+
+      const routeEffects = createRouteEffects()
+        // Append a route effect using a route reference
+        .append(routes.Root, delayTransition(0))
+        // Append a route effect using a route ID
+        .append(routes.Profile.id, delayTransition(0))
+        // Append a second route effect to the same route using a route reference
+        .append(routes.Profile, delayTransition(0))
+        // Add a transition complete listener using a route reference
+        .onComplete(routes.Profile, () => undefined);
+
+      expect(routeEffects).toMatchSnapshot();
+
+      assertType<"root">(routeEffects.handlers.RootMiddleware.id);
+      expect(routeEffects.handlers.RootMiddleware.id).toEqual("root");
+
+      assertType<"profile">(routeEffects.handlers.ProfileMiddleware.id);
+      expect(routeEffects.handlers.ProfileMiddleware.id).toEqual("profile");
+    });
+  });
+});

--- a/packages/router/src/__tests__/__snapshots__/RouteEffects.spec.ts.snap
+++ b/packages/router/src/__tests__/__snapshots__/RouteEffects.spec.ts.snap
@@ -1,0 +1,49 @@
+// Vitest Snapshot v1
+
+exports[`RoutesEffects > createRoutesEffects > appending route middleware 1`] = `
+{
+  "_clone": [Function],
+  "_getHandlersByRouteID": [Function],
+  "append": [Function],
+  "appendAll": [Function],
+  "handlers": {
+    "ProfileMiddleware": [Function],
+    "RootMiddleware": [Function],
+  },
+  "onComplete": [Function],
+  "onCompleteAll": [Function],
+  "onEnd": [Function],
+  "onEndAll": [Function],
+  "onExit": [Function],
+  "onExitAll": [Function],
+  "onFailure": [Function],
+  "onFailureAll": [Function],
+  "onInterrupt": [Function],
+  "onInterruptAll": [Function],
+  "onStart": [Function],
+  "onStartAll": [Function],
+  "prepend": [Function],
+  "prependAll": [Function],
+  Symbol(@sables/routeEffectsMeta): {
+    "listeners": Set {
+      {
+        "listenerReference": [Function],
+      },
+    },
+    "middleware": Set {
+      {
+        "middlewareReference": [Function],
+        "referenceKey": "RootMiddleware",
+      },
+      {
+        "middlewareReference": [Function],
+        "referenceKey": "ProfileMiddleware",
+      },
+      {
+        "middlewareReference": [Function],
+        "referenceKey": "ProfileMiddleware",
+      },
+    },
+  },
+}
+`;


### PR DESCRIPTION
### Overview

Allow `RouteReference` objects to be used with route effects methods.