### PR TITLE
Add notable entity ID selector

### DIFF
--- a/.changeset/calm-dolls-add.md
+++ b/.changeset/calm-dolls-add.md
@@ -1,0 +1,5 @@
+---
+"@sables/core": minor
+---
+
+Update notable entities to create selectors for selecting entity IDs, e.g. `selectBestBookId()`.

--- a/.changeset/lucky-drinks-hang.md
+++ b/.changeset/lucky-drinks-hang.md
@@ -1,0 +1,5 @@
+---
+"@sables/router": patch
+---
+
+Add missing `ensureLocation` export.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -718,12 +718,18 @@ const booksSlice = createSlice("books", {
     .addCases(notableBooks.reducers)
 );
 // Selectors are created for each adjective
-const { selectBestBook } = notableBooks.getSelectors(
-  booksSlice.selectBooksState
-);
+const {
+  selectBestBook,
+  selectBestBookId,
+  selectBestBookPayload,
+} = notableBooks.getSelectors(booksSlice.selectBooksState);
 
 // Returns `Book | undefined`
 selectBestBook(store.getState());
+// Returns `string | undefined`
+selectBestBookId(store.getState());
+// Returns `{ id: string; reason: string; }`
+selectBestBookPayload(store.getState());
 
 // Action creators are created for each adjective
 const { denoteBestBook } = booksSlice.actions;

--- a/packages/core/src/Slice.ts
+++ b/packages/core/src/Slice.ts
@@ -390,6 +390,7 @@ function createSliceReducerBuilder<
 }
 
 /** @public */
+// TODO - Make a valid slice with a noop reducer
 type DraftSlice<State, Name extends string = string> = {
   /**
    *

--- a/packages/core/src/__tests__/Entity.spec.ts
+++ b/packages/core/src/__tests__/Entity.spec.ts
@@ -166,8 +166,13 @@ describe("Entity", () => {
         builder.addCases(bookReducers).addCases(notableBooks.reducers)
       );
 
-      const { selectBestBook, selectWorstBook, selectFavoriteBook } =
-        notableBooks.getSelectors(booksSlice.selectBooksState);
+      const {
+        selectBestBook,
+        selectWorstBook,
+        selectFavoriteBook,
+        selectBestBookPayload,
+        selectBestBookId,
+      } = notableBooks.getSelectors(booksSlice.selectBooksState);
       const store = configureStore({
         reducer: combineReducers({
           books: booksSlice.reducer,
@@ -189,10 +194,13 @@ describe("Entity", () => {
         "selectFavoriteBook1"
       );
 
-      const denoteBestBookAction = booksSlice.actions.denoteBestBook({
+      const bestBookPayload = {
         id: "1",
         reason: "It's awesome!",
-      });
+      };
+
+      const denoteBestBookAction =
+        booksSlice.actions.denoteBestBook(bestBookPayload);
       const denoteWorstBookAction = booksSlice.actions.denoteWorstBook("2");
       const denoteFavoriteBookAction =
         booksSlice.actions.denoteFavoriteBook("3");
@@ -221,6 +229,12 @@ describe("Entity", () => {
       );
       expect(selectFavoriteBook(store.getState())).toMatchSnapshot(
         "selectFavoriteBook2"
+      );
+      expect(selectBestBookPayload(store.getState())).toStrictEqual(
+        bestBookPayload
+      );
+      expect(selectBestBookId(store.getState())).toStrictEqual(
+        bestBookPayload.id
       );
     });
   });

--- a/packages/core/src/__tests__/__snapshots__/EntitySlice.spec.ts.snap
+++ b/packages/core/src/__tests__/__snapshots__/EntitySlice.spec.ts.snap
@@ -89,6 +89,7 @@ exports[`EntitySlice > createEntitySlice > creates a slice with entity logic 1`]
             "selectAll": [Function],
             "selectAllBooks": [Function],
             "selectBestBook": [Function],
+            "selectBestBookId": [Function],
             "selectBestBookPayload": [Function],
             "selectBookById": [Function],
             "selectBookCount": [Function],

--- a/packages/router/src/main.ts
+++ b/packages/router/src/main.ts
@@ -1,6 +1,7 @@
 export {
   advanceLocation,
   chooseLocation,
+  ensureLocation,
   locationChange,
   pushLocation,
   replaceLocation,


### PR DESCRIPTION
### Overview

- Add missing `ensureLocation` export
- Update notable entities to create selectors for selecting entity IDs, e.g. `selectBestBookId()`.