### PR TITLE
Add `RouteEffects.onAdd` method

### DIFF
--- a/.changeset/lemon-hats-smash.md
+++ b/.changeset/lemon-hats-smash.md
@@ -1,0 +1,5 @@
+---
+"@sables/router": minor
+---
+
+Add `RouteEffects.onAdd` method.

--- a/docs/api.mdx
+++ b/docs/api.mdx
@@ -1242,24 +1242,25 @@ Route Effects object methods can be chained, and return a new object when called
 
 _`RouteEffects` methods include:_
 
-| Name                          | Type       | Target     | When                  |
-| ----------------------------- | ---------- | ---------- | --------------------- |
-| `RouteEffects.append`         | Middleware | one route  | middleware chain      |
-| `RouteEffects.appendAll`      | Middleware | all routes | middleware chain      |
-| `RouteEffects.prepend`        | Middleware | one route  | middleware chain      |
-| `RouteEffects.prependAll`     | Middleware | all routes | middleware chain      |
-| `RouteEffects.onComplete`     | Listener   | one route  | transition completes  |
-| `RouteEffects.onCompleteAll`  | Listener   | any route  | transition completes  |
-| `RouteEffects.onEnd`          | Listener   | one route  | transition ends       |
-| `RouteEffects.onEndAll`       | Listener   | any route  | transition ends       |
-| `RouteEffects.onExit`         | Listener   | one route  | transition exits      |
-| `RouteEffects.onExitAll`      | Listener   | any route  | transition exits      |
-| `RouteEffects.onFailure`      | Listener   | one route  | transition fails      |
-| `RouteEffects.onFailureAll`   | Listener   | any route  | transition fails      |
-| `RouteEffects.onInterrupt`    | Listener   | one route  | transition interrupts |
-| `RouteEffects.onInterruptAll` | Listener   | any route  | transition interrupts |
-| `RouteEffects.onStart`        | Listener   | one route  | transition starts     |
-| `RouteEffects.onStartAll`     | Listener   | any route  | transition starts     |
+| Name                          | Type       | Target     | When                    |
+| ----------------------------- | ---------- | ---------- | ----------------------- |
+| `RouteEffects.append`         | Middleware | one route  | middleware chain        |
+| `RouteEffects.appendAll`      | Middleware | all routes | middleware chain        |
+| `RouteEffects.prepend`        | Middleware | one route  | middleware chain        |
+| `RouteEffects.prependAll`     | Middleware | all routes | middleware chain        |
+| `RouteEffects.onComplete`     | Listener   | one route  | transition completes    |
+| `RouteEffects.onCompleteAll`  | Listener   | any route  | transition completes    |
+| `RouteEffects.onEnd`          | Listener   | one route  | transition ends         |
+| `RouteEffects.onEndAll`       | Listener   | any route  | transition ends         |
+| `RouteEffects.onExit`         | Listener   | one route  | transition exits        |
+| `RouteEffects.onExitAll`      | Listener   | any route  | transition exits        |
+| `RouteEffects.onFailure`      | Listener   | one route  | transition fails        |
+| `RouteEffects.onFailureAll`   | Listener   | any route  | transition fails        |
+| `RouteEffects.onInterrupt`    | Listener   | one route  | transition interrupts   |
+| `RouteEffects.onInterruptAll` | Listener   | any route  | transition interrupts   |
+| `RouteEffects.onStart`        | Listener   | one route  | transition starts       |
+| `RouteEffects.onStartAll`     | Listener   | any route  | transition starts       |
+| `RouteEffects.onAdd`          | Listener   | no routes  | route effects are added |
 
 #### RouteEffects.append
 
@@ -1287,8 +1288,6 @@ Adds middleware for all routes to the end of the stack.
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().appendAll(delayTransition(5000));
 ```
 
@@ -1318,8 +1317,6 @@ Adds middleware for all routes to the beginning of the stack.
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().prependAll(delayTransition(5000));
 ```
 
@@ -1348,8 +1345,6 @@ Adds a route listener that's called when a route transition for any route comple
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onCompleteAll(() => {
   console.log("A route transition completed.");
 });
@@ -1380,8 +1375,6 @@ Adds a route listener that's called when a route transition for any route ends.
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onEndAll(() => {
   console.log("A route transition ended.");
 });
@@ -1412,8 +1405,6 @@ Adds a route listener that's called when a route transition for any route exits.
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onExitAll(() => {
   console.log("A route transition exited.");
 });
@@ -1444,8 +1435,6 @@ Adds a route listener that's called when a route transition for any route fails.
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onFailureAll(() => {
   console.log("A route transition failed.");
 });
@@ -1476,8 +1465,6 @@ Adds a route listener that's called when a route transition for any route interr
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onInterruptAll(() => {
   console.log("A route transition was interrupted.");
 });
@@ -1508,10 +1495,24 @@ Adds a route listener that's called when a route transition for the given route 
 ##### Example
 
 ```ts
-const routes = createRoutes().set("root", "/");
-
 createRouteEffects().onStartAll(() => {
   console.log("A route transition started.");
+});
+```
+
+#### RouteEffects.onAdd
+
+> `RouteEffects.onAdd(routeListener): RouteEffects;`
+
+Adds a listener that's called when the route effects object
+is added to the router. The listener is only be called once
+in an application's lifecycle.
+
+##### Example
+
+```ts
+createRouteEffects().onAdd(() => {
+  console.log("Route effects were added to the route.");
 });
 ```
 

--- a/packages/core/src/Slice.ts
+++ b/packages/core/src/Slice.ts
@@ -441,7 +441,6 @@ type DraftSlice<State, Name extends string = string> = {
    *
    * @public
    */
-  // TODO - Rename to `reducer`
   setReducer<
     B extends SliceReducerBuilderBase<
       State,

--- a/packages/router/src/RouteTransitionMiddleware.ts
+++ b/packages/router/src/RouteTransitionMiddleware.ts
@@ -178,7 +178,18 @@ export function createRouteTransitionMiddleware<
         action.payload.location
       );
 
+      // For consistency, the middleware only invokes handlers from the
+      // routes object associated with the matched route.
+      //
+      // If this wasn't case, and the middleware invoked handlers for every
+      // added routes object, then the order of the invocations would be
+      // nondeterministic, because the order would be determined by when the
+      // routes object were added to the routes collection.
+      //
+      // Said order is nondeterministic, because the order is determined
+      // by which routes the end-user transitions to.
       const effectHandlers = await routes?._getHandlersByRouteID(
+        effectAPI,
         nextRoute?.id,
         createDynamicImportRegistrar(effectAPI)
       );

--- a/packages/router/src/__tests__/__snapshots__/RouteEffects.spec.ts.snap
+++ b/packages/router/src/__tests__/__snapshots__/RouteEffects.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`RoutesEffects > createRoutesEffects > appending route middleware 1`] = `
 {
   "_clone": [Function],
+  "_getAddHandler": [Function],
   "_getHandlersByRouteID": [Function],
   "append": [Function],
   "appendAll": [Function],
@@ -10,6 +11,7 @@ exports[`RoutesEffects > createRoutesEffects > appending route middleware 1`] = 
     "ProfileMiddleware": [Function],
     "RootMiddleware": [Function],
   },
+  "onAdd": [Function],
   "onComplete": [Function],
   "onCompleteAll": [Function],
   "onEnd": [Function],

--- a/packages/router/src/__tests__/integration.spec.ts
+++ b/packages/router/src/__tests__/integration.spec.ts
@@ -28,10 +28,10 @@ describe("integration", () => {
   test("setRoutes", async () => {
     let invokedImporters: Set<string> | undefined = undefined;
     const aboutDogsRouteEffect = vi.fn();
-    const aboutRouteEffects = createRouteEffects().append(
-      "aboutDogs",
-      aboutDogsRouteEffect
-    );
+    const aboutRouteEffectsAddListener = vi.fn();
+    const aboutRouteEffects = createRouteEffects()
+      .append("aboutDogs", aboutDogsRouteEffect)
+      .onAdd(aboutRouteEffectsAddListener);
 
     const aboutRouteEffectsImporter = mockImporter(
       vitest,
@@ -73,6 +73,8 @@ describe("integration", () => {
       await waitForRouteTransition();
       // Wait for `initialRouteEffects` to be resolved
       await Promise.resolve();
+      // Wait for `initialRouteEffects.onAdd` to be resolved
+      await Promise.resolve();
     }
     assertCurrentRouteID(initialRoutes.AppRoot.id);
 
@@ -101,6 +103,14 @@ describe("integration", () => {
     expect(invokedImporters).toHaveProperty("size", 2);
     expect(invokedImporters).toMatchSnapshot();
     expect(aboutDogsRouteEffect).not.toHaveBeenCalled();
+    expect(aboutRouteEffectsAddListener).not.toHaveBeenCalled();
+    {
+      // Wait for route effects add handler to resolve
+      await Promise.resolve();
+      // Wait for route effects add handler to be invoked
+      await Promise.resolve();
+    }
+    expect(aboutRouteEffectsAddListener).toHaveBeenCalledOnce();
     {
       // Wait for history replacement transition to end
       await waitForRouteTransition();

--- a/packages/router/src/actions.ts
+++ b/packages/router/src/actions.ts
@@ -169,6 +169,16 @@ export const ensureLocation = createAction<
 >("sablesRouter/ensureLocation") as EnsureLocation;
 
 /**
+ * Provided to Route Effects "onAdd" listeners.
+ *
+ * @internal
+ */
+export const initRouteEffects = createAction<
+  void,
+  "sablesRouter/initRouteEffects"
+>("sablesRouter/initRouteEffects");
+
+/**
  * Used to add router slices during router initialization.
  *
  * @internal

--- a/packages/router/src/constants.ts
+++ b/packages/router/src/constants.ts
@@ -24,7 +24,11 @@ export const endRouteTransitionReasons = {
 export const ALL_ROUTES_KEY = "@@sablesAllRoutes";
 
 /** @internal */
+export const NO_ROUTES_KEY = "@@sablesNoRoutes";
+
+/** @internal */
 export const hookNames = {
+  ADD: "add",
   COMPLETE: "complete",
   END: "end",
   EXIT: "exit",

--- a/packages/router/src/effects.ts
+++ b/packages/router/src/effects.ts
@@ -403,7 +403,7 @@ export function combineHandlers<EffectAPI extends DefaultEffectAPI>(
 ): RouteEffectHandlers<EffectAPI> {
   // prettier-ignore
   return {
-    middleware:  chainMiddleware(    ...handlersCollection.map(({ middleware })  => middleware)),
+    middleware:  chainMiddleware(...handlersCollection.map(({ middleware })   => middleware)),
     onComplete:  combineListeners(...handlersCollection.map(({ onComplete })  => onComplete)),
     onEnd:       combineListeners(...handlersCollection.map(({ onEnd })       => onEnd)),
     onExit:      combineListeners(...handlersCollection.map(({ onExit })      => onExit)),

--- a/packages/router/src/types.ts
+++ b/packages/router/src/types.ts
@@ -11,6 +11,7 @@ import type * as History from "history";
 import type * as Redux from "redux";
 import type * as ReduxFirstHistory from "redux-first-history";
 
+import type { initRouteEffects } from "./actions.js";
 import type {
   END_TRANSITION_ACTION_TYPE,
   endRouteTransitionReasons,
@@ -220,10 +221,14 @@ export type EndRouteTransitionActionPayload = {
 };
 
 /** @internal */
+export type InitRouteEffectsAction = ReturnType<typeof initRouteEffects>;
+
+/** @internal */
 export type StartTransitionAction = PayloadAction<
   StartRouteTransitionActionPayload,
   typeof START_TRANSITION_ACTION_TYPE
 >;
+
 /** @internal */
 export type EndTransitionAction = PayloadAction<
   EndRouteTransitionActionPayload,


### PR DESCRIPTION
### Overview

Adds a listener that's called when the route effects object is added to the router. The listener is only be called once in an application's lifecycle.